### PR TITLE
Replace Laravel Collective form helpers with Spatie HTML

### DIFF
--- a/app/Logic/Macros/HtmlMacros.php
+++ b/app/Logic/Macros/HtmlMacros.php
@@ -1,6 +1,9 @@
 <?php
 
-use Collective\Html\HtmlFacade as HTML;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\URL;
+use Illuminate\Support\HtmlString;
+use Spatie\Html\Facades\Html as HTML;
 
 /**
  * Render an image with an anchor tag around it.
@@ -15,12 +18,20 @@ use Collective\Html\HtmlFacade as HTML;
  *
  * @return string
  */
-HTML::macro('image_link', function ($url = '', $img = '', $alt = '', $link_name = '', $param = '', $active = true, $ssl = false) {
-    $url = $ssl === true ? URL::to_secure($url) : URL::to($url);
-    $img = HTML::image($img, $alt);
-    $img .= $link_name;
-    $link = $active === true ? HTML::link($url, '#', $param) : $img;
-    $link = str_replace('#', $img, $link);
+HTML::macro('image_link', function ($url = '', $img = '', $alt = '', $link_name = '', $param = [], $active = true, $ssl = false) {
+    $url = URL::to($url, [], $ssl === true);
+    $imageHtml = (string) HTML::img($img, $alt);
+    $imageHtml .= $link_name;
+
+    if ($active !== true) {
+        return new HtmlString($imageHtml);
+    }
+
+    $link = HTML::a($url)->html($imageHtml);
+
+    if (is_array($param) && ! empty($param)) {
+        $link = $link->attributes($param);
+    }
 
     return $link;
 });
@@ -37,11 +48,19 @@ HTML::macro('image_link', function ($url = '', $img = '', $alt = '', $link_name 
  *
  * @return string
  */
-HTML::macro('icon_link', function ($url = '', $icon = '', $link_name = '', $param = '', $active = true, $ssl = false) {
-    $url = $ssl === true ? URL::to_secure($url) : URL::to($url);
-    $icon = '<i class="'.$icon.'" aria-hidden="true"></i>'.$link_name;
-    $link = $active === true ? HTML::link($url, '#', $param) : $icon;
-    $link = str_replace('#', $icon, $link);
+HTML::macro('icon_link', function ($url = '', $icon = '', $link_name = '', $param = [], $active = true, $ssl = false) {
+    $url = URL::to($url, [], $ssl === true);
+    $iconHtml = '<i class="'.$icon.'" aria-hidden="true"></i>'.$link_name;
+
+    if ($active !== true) {
+        return new HtmlString($iconHtml);
+    }
+
+    $link = HTML::a($url)->html($iconHtml);
+
+    if (is_array($param) && ! empty($param)) {
+        $link = $link->attributes($param);
+    }
 
     return $link;
 });
@@ -58,11 +77,19 @@ HTML::macro('icon_link', function ($url = '', $icon = '', $link_name = '', $para
  *
  * @return string
  */
-HTML::macro('icon_btn', function ($url = '', $icon = '', $link_name = '', $param = '', $active = true, $ssl = false) {
-    $url = $ssl === true ? URL::to_secure($url) : URL::to($url);
-    $icon = $link_name.' <i class="'.$icon.'" aria-hidden="true"></i>';
-    $link = $active === true ? HTML::link($url, '#', $param) : $icon;
-    $link = str_replace('#', $icon, $link);
+HTML::macro('icon_btn', function ($url = '', $icon = '', $link_name = '', $param = [], $active = true, $ssl = false) {
+    $url = URL::to($url, [], $ssl === true);
+    $iconHtml = $link_name.' <i class="'.$icon.'" aria-hidden="true"></i>';
+
+    if ($active !== true) {
+        return new HtmlString($iconHtml);
+    }
+
+    $link = HTML::a($url)->html($iconHtml);
+
+    if (is_array($param) && ! empty($param)) {
+        $link = $link->attributes($param);
+    }
 
     return $link;
 });

--- a/app/Providers/MacroServiceProvider.php
+++ b/app/Providers/MacroServiceProvider.php
@@ -3,7 +3,7 @@
 namespace App\Providers;
 
 use App\Logic\Macros\Macros;
-use Collective\Html\HtmlServiceProvider;
+use Spatie\Html\HtmlServiceProvider;
 
 /**
  * Class MacroServiceProvider.

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,6 @@
     "laravel/socialite": "^5.6",
     "laravel/tinker": "^2.8",
     "laravel/ui": "^4.2",
-    "laravelcollective/html": "^6.4",
     "nesbot/carbon": "^2.66",
     "predis/predis": "^2.1",
     "pusher/pusher-php-server": "^7.2",
@@ -39,7 +38,8 @@
     "socialiteproviders/instagram": "^5.0",
     "socialiteproviders/linkedin": "^4.2",
     "socialiteproviders/twitch": "^5.3",
-    "socialiteproviders/youtube": "^4.1"
+    "socialiteproviders/youtube": "^4.1",
+    "spatie/laravel-html": "^3.12"
   },
   "require-dev": {
     "fakerphp/faker": "^1.9.1",

--- a/config/app.php
+++ b/config/app.php
@@ -2,8 +2,6 @@
 
 use App\Providers\ComposerServiceProvider;
 use App\Providers\MacroServiceProvider;
-use Collective\Html\FormFacade;
-use Collective\Html\HtmlFacade;
 use Creativeorange\Gravatar\Facades\Gravatar;
 use Illuminate\Support\Facades\Facade;
 use Illuminate\Support\Facades\Input;
@@ -221,8 +219,6 @@ return [
 
     'aliases' => Facade::defaultAliases()->merge([
         'Redis'     => Redis::class,
-        'Form'      => FormFacade::class,
-        'HTML'      => HtmlFacade::class,
         'Socialite' => Socialite::class,
         'Input'     => Input::class,
         'Gravatar'  => Gravatar::class,

--- a/resources/views/modals/modal-delete.blade.php
+++ b/resources/views/modals/modal-delete.blade.php
@@ -14,8 +14,14 @@
         <p>Delete this user?</p>
       </div>
       <div class="modal-footer">
-        {!! Form::button('<i class="fa fa-fw fa-close" aria-hidden="true"></i> Cancel', array('class' => 'btn btn-outline pull-left btn-light', 'type' => 'button', 'data-dismiss' => 'modal' )) !!}
-        {!! Form::button('<i class="fa fa-fw fa-trash-o" aria-hidden="true"></i> Confirm Delete', array('class' => 'btn btn-danger pull-right', 'type' => 'button', 'id' => 'confirm' )) !!}
+        {{ html()->button('<i class="fa fa-fw fa-close" aria-hidden="true"></i> Cancel')
+            ->class('btn btn-outline pull-left btn-light')
+            ->type('button')
+            ->attribute('data-dismiss', 'modal') }}
+        {{ html()->button('<i class="fa fa-fw fa-trash-o" aria-hidden="true"></i> Confirm Delete')
+            ->class('btn btn-danger pull-right')
+            ->type('button')
+            ->id('confirm') }}
       </div>
     </div>
   </div>

--- a/resources/views/modals/modal-form.blade.php
+++ b/resources/views/modals/modal-form.blade.php
@@ -13,8 +13,14 @@
         </p>
       </div>
       <div class="modal-footer">
-        {!! Form::button('<i class="fa fa-fw fa-close" aria-hidden="true"></i> ' . trans('modals.form_modal_default_btn_cancel'), array('class' => 'btn btn-secondary', 'type' => 'button', 'data-dismiss' => 'modal' )) !!}
-        {!! Form::button('<i class="fa fa-fw fa-check" aria-hidden="true"></i> ' . trans('modals.form_modal_default_btn_submit'), array('class' => 'btn btn-primary', 'type' => 'button', 'id' => 'confirm' )) !!}
+        {{ html()->button('<i class="fa fa-fw fa-close" aria-hidden="true"></i> ' . trans('modals.form_modal_default_btn_cancel'))
+            ->class('btn btn-secondary')
+            ->type('button')
+            ->attribute('data-dismiss', 'modal') }}
+        {{ html()->button('<i class="fa fa-fw fa-check" aria-hidden="true"></i> ' . trans('modals.form_modal_default_btn_submit'))
+            ->class('btn btn-primary')
+            ->type('button')
+            ->id('confirm') }}
       </div>
     </div>
   </div>

--- a/resources/views/modals/modal-save.blade.php
+++ b/resources/views/modals/modal-save.blade.php
@@ -16,8 +16,14 @@
                 </p>
             </div>
             <div class="modal-footer">
-                {!! Form::button('<i class="fa fa-fw '.trans('modals.confirm_modal_button_cancel_icon').'" aria-hidden="true"></i> ' . trans('modals.confirm_modal_button_cancel_text'), array('class' => 'btn btn-outline pull-left btn-flat', 'type' => 'button', 'data-dismiss' => 'modal' )) !!}
-                {!! Form::button('<i class="fa fa-fw '.trans('modals.confirm_modal_button_save_icon').'" aria-hidden="true"></i> ' . trans('modals.confirm_modal_button_save_text'), array('class' => 'btn btn-success pull-right btn-flat', 'type' => 'button', 'id' => 'confirm' )) !!}
+                {{ html()->button('<i class="fa fa-fw '.trans('modals.confirm_modal_button_cancel_icon').'" aria-hidden="true"></i> ' . trans('modals.confirm_modal_button_cancel_text'))
+                    ->class('btn btn-outline pull-left btn-flat')
+                    ->type('button')
+                    ->attribute('data-dismiss', 'modal') }}
+                {{ html()->button('<i class="fa fa-fw '.trans('modals.confirm_modal_button_save_icon').'" aria-hidden="true"></i> ' . trans('modals.confirm_modal_button_save_text'))
+                    ->class('btn btn-success pull-right btn-flat')
+                    ->type('button')
+                    ->id('confirm') }}
             </div>
         </div>
     </div>

--- a/resources/views/partials/search-users-form.blade.php
+++ b/resources/views/partials/search-users-form.blade.php
@@ -1,9 +1,17 @@
 <div class="row">
     <div class="col-sm-8 offset-sm-4 col-md-6 offset-md-6 col-lg-5 offset-lg-7 col-xl-4 offset-xl-8">
-        {!! Form::open(['route' => 'search-users', 'method' => 'POST', 'role' => 'form', 'class' => 'needs-validation', 'id' => 'search_users']) !!}
-            {!! csrf_field() !!}
+        {{ html()->form('POST', route('search-users'))
+                ->attribute('role', 'form')
+                ->class('needs-validation')
+                ->id('search_users')
+                ->open() }}
+            @csrf
             <div class="input-group mb-3">
-                {!! Form::text('user_search_box', NULL, ['id' => 'user_search_box', 'class' => 'form-control', 'placeholder' => trans('usersmanagement.search.search-users-ph'), 'aria-label' => trans('usersmanagement.search.search-users-ph'), 'required' => false]) !!}
+                {{ html()->text('user_search_box')
+                        ->id('user_search_box')
+                        ->class('form-control')
+                        ->placeholder(trans('usersmanagement.search.search-users-ph'))
+                        ->attribute('aria-label', trans('usersmanagement.search.search-users-ph')) }}
                 <div class="input-group-append">
                     <a href="#" class="input-group-addon btn btn-warning clear-search" data-toggle="tooltip" title="{{ trans('usersmanagement.tooltips.clear-search') }}" style="display:none;">
                         <i class="fa fa-fw fa-times" aria-hidden="true"></i>
@@ -19,6 +27,6 @@
                     </a>
                 </div>
             </div>
-        {!! Form::close() !!}
+        {{ html()->form()->close() }}
     </div>
 </div>

--- a/resources/views/profiles/edit.blade.php
+++ b/resources/views/profiles/edit.blade.php
@@ -41,16 +41,29 @@
                                                             <div class="collapseTwo card-collapse collapse @if($user->profile->avatar_status == 1) show @endif">
                                                                 <div class="card-body">
                                                                     <div class="dz-preview"></div>
-                                                                    {!! Form::open(array('route' => 'avatar.upload', 'method' => 'POST', 'name' => 'avatarDropzone','id' => 'avatarDropzone', 'class' => 'form single-dropzone dropzone single', 'files' => true)) !!}
+                                                                    {{ html()->form('POST', route('avatar.upload'))
+                                                                            ->name('avatarDropzone')
+                                                                            ->id('avatarDropzone')
+                                                                            ->class('form single-dropzone dropzone single')
+                                                                            ->acceptsFiles()
+                                                                            ->open() }}
+                                                                        @csrf
                                                                         <img id="user_selected_avatar" class="user-avatar" src="@if ($user->profile->avatar != NULL) {{ $user->profile->avatar }} @endif" alt="{{ $user->name }}">
-                                                                    {!! Form::close() !!}
+                                                                    {{ html()->form()->close() }}
                                                                 </div>
                                                             </div>
                                                         </div>
                                                     </div>
                                                 </div>
-                                                {!! Form::model($user->profile, ['method' => 'PATCH', 'route' => ['profile.update', $user->name], 'id' => 'user_profile_form', 'class' => 'form-horizontal', 'role' => 'form', 'enctype' => 'multipart/form-data']) !!}
-                                                    {{ csrf_field() }}
+                                                {{ html()->model($user->profile) }}
+                                                {{ html()->form('POST', route('profile.update', $user->name))
+                                                        ->id('user_profile_form')
+                                                        ->class('form-horizontal')
+                                                        ->attribute('role', 'form')
+                                                        ->acceptsFiles()
+                                                        ->open() }}
+                                                    @csrf
+                                                    @method('PATCH')
                                                     <div class="row">
                                                         <div class="col-10 offset-1 col-sm-10 offset-sm-1 mb-1">
                                                             <div class="row" data-toggle="buttons">
@@ -68,7 +81,7 @@
                                                         </div>
                                                     </div>
                                                     <div class="form-group has-feedback {{ $errors->has('theme') ? ' has-error ' : '' }}">
-                                                        {!! Form::label('theme_id', trans('profile.label-theme') , array('class' => 'col-12 control-label')); !!}
+                                                        {{ html()->label('theme_id', trans('profile.label-theme'))->class('col-12 control-label') }}
                                                         <div class="col-12">
                                                             <select class="form-control" name="theme_id" id="theme_id">
                                                                 @if ($themes->count())
@@ -86,9 +99,9 @@
                                                         </div>
                                                     </div>
                                                     <div class="form-group has-feedback {{ $errors->has('location') ? ' has-error ' : '' }}">
-                                                        {!! Form::label('location', trans('profile.label-location') , array('class' => 'col-12 control-label')); !!}
+                                                        {{ html()->label('location', trans('profile.label-location'))->class('col-12 control-label') }}
                                                         <div class="col-12">
-                                                            {!! Form::text('location', old('location'), array('id' => 'location', 'class' => 'form-control', 'placeholder' => trans('profile.ph-location'))) !!}
+                                                            {{ html()->text('location')->id('location')->class('form-control')->placeholder(trans('profile.ph-location')) }}
                                                             <span class="glyphicon {{ $errors->has('location') ? ' glyphicon-asterisk ' : ' glyphicon-pencil ' }} form-control-feedback" aria-hidden="true"></span>
                                                             @if ($errors->has('location'))
                                                                 <span class="help-block">
@@ -98,9 +111,9 @@
                                                         </div>
                                                     </div>
                                                     <div class="form-group has-feedback {{ $errors->has('bio') ? ' has-error ' : '' }}">
-                                                        {!! Form::label('bio', trans('profile.label-bio') , array('class' => 'col-12 control-label')); !!}
+                                                        {{ html()->label('bio', trans('profile.label-bio'))->class('col-12 control-label') }}
                                                         <div class="col-12">
-                                                            {!! Form::textarea('bio', old('bio'), array('id' => 'bio', 'class' => 'form-control', 'placeholder' => trans('profile.ph-bio'))) !!}
+                                                            {{ html()->textarea('bio')->id('bio')->class('form-control')->placeholder(trans('profile.ph-bio')) }}
                                                             <span class="glyphicon glyphicon-pencil form-control-feedback" aria-hidden="true"></span>
                                                             @if ($errors->has('bio'))
                                                                 <span class="help-block">
@@ -110,9 +123,9 @@
                                                         </div>
                                                     </div>
                                                     <div class="form-group has-feedback {{ $errors->has('twitter_username') ? ' has-error ' : '' }}">
-                                                        {!! Form::label('twitter_username', trans('profile.label-twitter_username') , array('class' => 'col-12 control-label')); !!}
+                                                        {{ html()->label('twitter_username', trans('profile.label-twitter_username'))->class('col-12 control-label') }}
                                                         <div class="col-12">
-                                                            {!! Form::text('twitter_username', old('twitter_username'), array('id' => 'twitter_username', 'class' => 'form-control', 'placeholder' => trans('profile.ph-twitter_username'))) !!}
+                                                            {{ html()->text('twitter_username')->id('twitter_username')->class('form-control')->placeholder(trans('profile.ph-twitter_username')) }}
                                                             <span class="glyphicon glyphicon-pencil form-control-feedback" aria-hidden="true"></span>
                                                             @if ($errors->has('twitter_username'))
                                                                 <span class="help-block">
@@ -122,9 +135,9 @@
                                                         </div>
                                                     </div>
                                                     <div class="margin-bottom-2 form-group has-feedback {{ $errors->has('github_username') ? ' has-error ' : '' }}">
-                                                        {!! Form::label('github_username', trans('profile.label-github_username') , array('class' => 'col-12 control-label')); !!}
+                                                        {{ html()->label('github_username', trans('profile.label-github_username'))->class('col-12 control-label') }}
                                                         <div class="col-12">
-                                                            {!! Form::text('github_username', old('github_username'), array('id' => 'github_username', 'class' => 'form-control', 'placeholder' => trans('profile.ph-github_username'))) !!}
+                                                            {{ html()->text('github_username')->id('github_username')->class('form-control')->placeholder(trans('profile.ph-github_username')) }}
                                                             <span class="glyphicon glyphicon-pencil form-control-feedback" aria-hidden="true"></span>
                                                             @if ($errors->has('github_username'))
                                                                 <span class="help-block">
@@ -135,34 +148,36 @@
                                                     </div>
                                                     <div class="form-group margin-bottom-2">
                                                         <div class="col-12">
-                                                            {!! Form::button(
-                                                                '<i class="fa fa-fw fa-save" aria-hidden="true"></i> ' . trans('profile.submitButton'),
-                                                                 array(
-                                                                    'id'                => 'confirmFormSave',
-                                                                    'class'             => 'btn btn-success disabled',
-                                                                    'type'              => 'button',
-                                                                    'data-target'       => '#confirmForm',
-                                                                    'data-modalClass'   => 'modal-success',
-                                                                    'data-toggle'       => 'modal',
-                                                                    'data-title'        => trans('modals.edit_user__modal_text_confirm_title'),
-                                                                    'data-message'      => trans('modals.edit_user__modal_text_confirm_message')
-                                                            )) !!}
+                                                            {{ html()->button('<i class="fa fa-fw fa-save" aria-hidden="true"></i> ' . trans('profile.submitButton'))
+                                                                ->id('confirmFormSave')
+                                                                ->class('btn btn-success disabled')
+                                                                ->type('button')
+                                                                ->attribute('data-target', '#confirmForm')
+                                                                ->attribute('data-modalClass', 'modal-success')
+                                                                ->attribute('data-toggle', 'modal')
+                                                                ->attribute('data-title', trans('modals.edit_user__modal_text_confirm_title'))
+                                                                ->attribute('data-message', trans('modals.edit_user__modal_text_confirm_message')) }}
 
                                                         </div>
                                                     </div>
-                                                {!! Form::close() !!}
+                                                {{ html()->form()->close() }}
+                                                {{ html()->endModel() }}
                                             </div>
 
                                             <div class="tab-pane fade edit-settings-tab" role="tabpanel" aria-labelledby="edit-settings-tab">
-                                                {!! Form::model($user, array('action' => array('ProfilesController@updateUserAccount', $user->id), 'method' => 'PUT', 'id' => 'user_basics_form')) !!}
+                                                {{ html()->model($user) }}
+                                                {{ html()->form('POST', action([App\Http\Controllers\ProfilesController::class, 'updateUserAccount'], $user->id))
+                                                        ->id('user_basics_form')
+                                                        ->open() }}
 
-                                                    {!! csrf_field() !!}
+                                                    @csrf
+                                                    @method('PUT')
 
                                                     <div class="pt-4 pr-3 pl-2 form-group has-feedback row {{ $errors->has('name') ? ' has-error ' : '' }}">
-                                                        {!! Form::label('name', trans('forms.create_user_label_username'), array('class' => 'col-md-3 control-label')); !!}
+                                                        {{ html()->label('name', trans('forms.create_user_label_username'))->class('col-md-3 control-label') }}
                                                         <div class="col-md-9">
                                                             <div class="input-group">
-                                                                {!! Form::text('name', $user->name, array('id' => 'name', 'class' => 'form-control', 'placeholder' => trans('forms.create_user_ph_username'))) !!}
+                                                                {{ html()->text('name')->id('name')->class('form-control')->placeholder(trans('forms.create_user_ph_username')) }}
                                                                 <div class="input-group-append">
                                                                     <label class="input-group-text" for="name">
                                                                         <i class="fa fa-fw {{ trans('forms.create_user_icon_username') }}" aria-hidden="true"></i>
@@ -178,10 +193,10 @@
                                                     </div>
 
                                                     <div class="pr-3 pl-2 form-group has-feedback row {{ $errors->has('email') ? ' has-error ' : '' }}">
-                                                        {!! Form::label('email', trans('forms.create_user_label_email'), array('class' => 'col-md-3 control-label')); !!}
+                                                        {{ html()->label('email', trans('forms.create_user_label_email'))->class('col-md-3 control-label') }}
                                                         <div class="col-md-9">
                                                             <div class="input-group">
-                                                                {!! Form::text('email', $user->email, array('id' => 'email', 'class' => 'form-control', 'placeholder' => trans('forms.create_user_ph_email'))) !!}
+                                                                {{ html()->email('email')->id('email')->class('form-control')->placeholder(trans('forms.create_user_ph_email')) }}
                                                                 <div class="input-group-append">
                                                                     <label for="email" class="input-group-text">
                                                                         <i class="fa fa-fw {{ trans('forms.create_user_icon_email') }}" aria-hidden="true"></i>
@@ -197,10 +212,10 @@
                                                     </div>
 
                                                     <div class="pr-3 pl-2 form-group has-feedback row {{ $errors->has('first_name') ? ' has-error ' : '' }}">
-                                                        {!! Form::label('first_name', trans('forms.create_user_label_firstname'), array('class' => 'col-md-3 control-label')); !!}
+                                                        {{ html()->label('first_name', trans('forms.create_user_label_firstname'))->class('col-md-3 control-label') }}
                                                         <div class="col-md-9">
                                                             <div class="input-group">
-                                                                {!! Form::text('first_name', $user->first_name, array('id' => 'first_name', 'class' => 'form-control', 'placeholder' => trans('forms.create_user_ph_firstname'))) !!}
+                                                                {{ html()->text('first_name')->id('first_name')->class('form-control')->placeholder(trans('forms.create_user_ph_firstname')) }}
                                                                 <div class="input-group-append">
                                                                     <label class="input-group-text" for="first_name">
                                                                         <i class="fa fa-fw {{ trans('forms.create_user_icon_firstname') }}" aria-hidden="true"></i>
@@ -216,10 +231,10 @@
                                                     </div>
 
                                                     <div class="pr-3 pl-2 form-group has-feedback row {{ $errors->has('last_name') ? ' has-error ' : '' }}">
-                                                        {!! Form::label('last_name', trans('forms.create_user_label_lastname'), array('class' => 'col-md-3 control-label')); !!}
+                                                        {{ html()->label('last_name', trans('forms.create_user_label_lastname'))->class('col-md-3 control-label') }}
                                                         <div class="col-md-9">
                                                             <div class="input-group">
-                                                                {!! Form::text('last_name', $user->last_name, array('id' => 'last_name', 'class' => 'form-control', 'placeholder' => trans('forms.create_user_ph_lastname'))) !!}
+                                                                {{ html()->text('last_name')->id('last_name')->class('form-control')->placeholder(trans('forms.create_user_ph_lastname')) }}
                                                                 <div class="input-group-append">
                                                                     <label class="input-group-text" for="last_name">
                                                                         <i class="fa fa-fw {{ trans('forms.create_user_icon_lastname') }}" aria-hidden="true"></i>
@@ -236,23 +251,21 @@
 
                                                     <div class="form-group row">
                                                         <div class="col-md-9 offset-md-3">
-                                                            {!! Form::button(
-                                                                '<i class="fa fa-fw fa-save" aria-hidden="true"></i> ' . trans('profile.submitProfileButton'),
-                                                                 array(
-                                                                    'class'             => 'btn btn-success disabled',
-                                                                    'id'                => 'account_save_trigger',
-                                                                    'disabled'          => true,
-                                                                    'type'              => 'button',
-                                                                    'data-submit'       => trans('profile.submitProfileButton'),
-                                                                    'data-target'       => '#confirmForm',
-                                                                    'data-modalClass'   => 'modal-success',
-                                                                    'data-toggle'       => 'modal',
-                                                                    'data-title'        => trans('modals.edit_user__modal_text_confirm_title'),
-                                                                    'data-message'      => trans('modals.edit_user__modal_text_confirm_message')
-                                                            )) !!}
+                                                            {{ html()->button('<i class="fa fa-fw fa-save" aria-hidden="true"></i> ' . trans('profile.submitProfileButton'))
+                                                                ->class('btn btn-success disabled')
+                                                                ->id('account_save_trigger')
+                                                                ->disabled()
+                                                                ->type('button')
+                                                                ->attribute('data-submit', trans('profile.submitProfileButton'))
+                                                                ->attribute('data-target', '#confirmForm')
+                                                                ->attribute('data-modalClass', 'modal-success')
+                                                                ->attribute('data-toggle', 'modal')
+                                                                ->attribute('data-title', trans('modals.edit_user__modal_text_confirm_title'))
+                                                                ->attribute('data-message', trans('modals.edit_user__modal_text_confirm_message')) }}
                                                         </div>
                                                     </div>
-                                                {!! Form::close() !!}
+                                                {{ html()->form()->close() }}
+                                                {{ html()->endModel() }}
                                             </div>
 
                                             <div class="tab-pane fade edit-account-tab" role="tabpanel" aria-labelledby="edit-account-tab">
@@ -276,14 +289,20 @@
                                                             {{ trans('profile.changePwTitle') }}
                                                         </h3>
 
-                                                        {!! Form::model($user, array('action' => array('ProfilesController@updateUserPassword', $user->id), 'method' => 'PUT', 'autocomplete' => 'new-password')) !!}
+                                                        {{ html()->model($user) }}
+                                                        {{ html()->form('POST', action([App\Http\Controllers\ProfilesController::class, 'updateUserPassword'], $user->id))
+                                                                ->attribute('autocomplete', 'new-password')
+                                                                ->open() }}
+
+                                                            @csrf
+                                                            @method('PUT')
 
                                                             <div class="pw-change-container margin-bottom-2">
 
                                                                 <div class="form-group has-feedback row {{ $errors->has('password') ? ' has-error ' : '' }}">
-                                                                    {!! Form::label('password', trans('forms.create_user_label_password'), array('class' => 'col-md-3 control-label')); !!}
+                                                                    {{ html()->label('password', trans('forms.create_user_label_password'))->class('col-md-3 control-label') }}
                                                                     <div class="col-md-9">
-                                                                        {!! Form::password('password', array('id' => 'password', 'class' => 'form-control ', 'placeholder' => trans('forms.create_user_ph_password'), 'autocomplete' => 'new-password')) !!}
+                                                                        {{ html()->password('password')->id('password')->class('form-control ')->placeholder(trans('forms.create_user_ph_password'))->attribute('autocomplete', 'new-password') }}
                                                                         @if ($errors->has('password'))
                                                                             <span class="help-block">
                                                                                 <strong>{{ $errors->first('password') }}</strong>
@@ -293,9 +312,9 @@
                                                                 </div>
 
                                                                 <div class="form-group has-feedback row {{ $errors->has('password_confirmation') ? ' has-error ' : '' }}">
-                                                                    {!! Form::label('password_confirmation', trans('forms.create_user_label_pw_confirmation'), array('class' => 'col-md-3 control-label')); !!}
+                                                                    {{ html()->label('password_confirmation', trans('forms.create_user_label_pw_confirmation'))->class('col-md-3 control-label') }}
                                                                     <div class="col-md-9">
-                                                                        {!! Form::password('password_confirmation', array('id' => 'password_confirmation', 'class' => 'form-control', 'placeholder' => trans('forms.create_user_ph_pw_confirmation'))) !!}
+                                                                        {{ html()->password('password_confirmation')->id('password_confirmation')->class('form-control')->placeholder(trans('forms.create_user_ph_pw_confirmation')) }}
                                                                         <span id="pw_status"></span>
                                                                         @if ($errors->has('password_confirmation'))
                                                                             <span class="help-block">
@@ -307,23 +326,21 @@
                                                             </div>
                                                             <div class="form-group row">
                                                                 <div class="col-md-9 offset-md-3">
-                                                                    {!! Form::button(
-                                                                        '<i class="fa fa-fw fa-save" aria-hidden="true"></i> ' . trans('profile.submitPWButton'),
-                                                                         array(
-                                                                            'class'             => 'btn btn-warning',
-                                                                            'id'                => 'pw_save_trigger',
-                                                                            'disabled'          => true,
-                                                                            'type'              => 'button',
-                                                                            'data-submit'       => trans('profile.submitButton'),
-                                                                            'data-target'       => '#confirmForm',
-                                                                            'data-modalClass'   => 'modal-warning',
-                                                                            'data-toggle'       => 'modal',
-                                                                            'data-title'        => trans('modals.edit_user__modal_text_confirm_title'),
-                                                                            'data-message'      => trans('modals.edit_user__modal_text_confirm_message')
-                                                                    )) !!}
+                                                                    {{ html()->button('<i class="fa fa-fw fa-save" aria-hidden="true"></i> ' . trans('profile.submitPWButton'))
+                                                                        ->class('btn btn-warning')
+                                                                        ->id('pw_save_trigger')
+                                                                        ->disabled()
+                                                                        ->type('button')
+                                                                        ->attribute('data-submit', trans('profile.submitButton'))
+                                                                        ->attribute('data-target', '#confirmForm')
+                                                                        ->attribute('data-modalClass', 'modal-warning')
+                                                                        ->attribute('data-toggle', 'modal')
+                                                                        ->attribute('data-title', trans('modals.edit_user__modal_text_confirm_title'))
+                                                                        ->attribute('data-message', trans('modals.edit_user__modal_text_confirm_message')) }}
                                                                 </div>
                                                             </div>
-                                                        {!! Form::close() !!}
+                                                        {{ html()->form()->close() }}
+                                                        {{ html()->endModel() }}
 
                                                     </div>
 
@@ -340,7 +357,12 @@
                                                         <div class="row">
                                                             <div class="col-sm-6 offset-sm-3 margin-bottom-3 text-center">
 
-                                                                {!! Form::model($user, array('action' => array('ProfilesController@deleteUserAccount', $user->id), 'method' => 'DELETE')) !!}
+                                                                {{ html()->model($user) }}
+                                                                {{ html()->form('POST', action([App\Http\Controllers\ProfilesController::class, 'deleteUserAccount'], $user->id))
+                                                                        ->open() }}
+
+                                                                    @csrf
+                                                                    @method('DELETE')
 
                                                                     <div class="btn-group btn-group-vertical margin-bottom-2 custom-checkbox-fa" data-toggle="buttons">
                                                                         <label class="btn no-shadow" for="checkConfirmDelete" >
@@ -351,23 +373,20 @@
                                                                         </label>
                                                                     </div>
 
-                                                                    {!! Form::button(
-                                                                        '<i class="fa fa-trash-o fa-fw" aria-hidden="true"></i> ' . trans('profile.deleteAccountBtn'),
-                                                                        array(
-                                                                            'class'             => 'btn btn-block btn-danger',
-                                                                            'id'                => 'delete_account_trigger',
-                                                                            'disabled'          => true,
-                                                                            'type'              => 'button',
-                                                                            'data-toggle'       => 'modal',
-                                                                            'data-submit'       => trans('profile.deleteAccountBtnConfirm'),
-                                                                            'data-target'       => '#confirmForm',
-                                                                            'data-modalClass'   => 'modal-danger',
-                                                                            'data-title'        => trans('profile.deleteAccountConfirmTitle'),
-                                                                            'data-message'      => trans('profile.deleteAccountConfirmMsg')
-                                                                        )
-                                                                    ) !!}
+                                                                    {{ html()->button('<i class="fa fa-trash-o fa-fw" aria-hidden="true"></i>' . trans('profile.deleteAccountBtn'))
+                ->class('btn btn-block btn-danger')
+                ->id('delete_account_trigger')
+                ->disabled()
+                ->type('button')
+                ->attribute('data-toggle', 'modal')
+                ->attribute('data-submit', trans('profile.deleteAccountBtnConfirm'))
+                ->attribute('data-target', '#confirmForm')
+                ->attribute('data-modalClass', 'modal-danger')
+                ->attribute('data-title', trans('profile.deleteAccountConfirmTitle'))
+                ->attribute('data-message', trans('profile.deleteAccountConfirmMsg')) }}
 
-                                                                {!! Form::close() !!}
+                                                                {{ html()->form()->close() }}
+                                                                {{ html()->endModel() }}
 
                                                             </div>
                                                         </div>

--- a/resources/views/scripts/search-users.blade.php
+++ b/resources/views/scripts/search-users.blade.php
@@ -46,8 +46,8 @@
                             let showCellHtml = '<a class="btn btn-sm btn-success btn-block" href="users/' + val.id + '" data-toggle="tooltip" title="{{ trans("usersmanagement.tooltips.show") }}">{!! trans("usersmanagement.buttons.show") !!}</a>';
                             let editCellHtml = '<a class="btn btn-sm btn-info btn-block" href="users/' + val.id + '/edit" data-toggle="tooltip" title="{{ trans("usersmanagement.tooltips.edit") }}">{!! trans("usersmanagement.buttons.edit") !!}</a>';
                             let deleteCellHtml = '<form method="POST" action="/users/'+ val.id +'" accept-charset="UTF-8" data-toggle="tooltip" title="Delete">' +
-                                    '{!! Form::hidden("_method", "DELETE") !!}' +
-                                    '{!! csrf_field() !!}' +
+                                    '<input type="hidden" name="_method" value="DELETE">' +
+                                    '<input type="hidden" name="_token" value="{{ csrf_token() }}">' +
                                     '<button class="btn btn-danger btn-sm" type="button" style="width: 100%;" data-toggle="modal" data-target="#confirmDelete" data-title="Delete User" data-message="{!! trans("usersmanagement.modals.delete_user_message", ["user" => "'+val.name+'"]) !!}">' +
                                         '{!! trans("usersmanagement.buttons.delete") !!}' +
                                     '</button>' +

--- a/resources/views/themesmanagement/add-theme.blade.php
+++ b/resources/views/themesmanagement/add-theme.blade.php
@@ -27,14 +27,16 @@
                     </div>
 
 
-                    {!! Form::open(array('action' => 'ThemesManagementController@store', 'method' => 'POST', 'role' => 'form')) !!}
+                    {{ html()->form('POST', action([App\Http\Controllers\ThemesManagementController::class, 'store']))
+                            ->attribute('role', 'form')
+                            ->open() }}
 
-                        {!! csrf_field() !!}
+                        @csrf
 
                         <div class="card-body">
 
                             <div class="form-group has-feedback row {{ $errors->has('status') ? ' has-error ' : '' }}">
-                                {!! Form::label('status', trans('themes.statusLabel') , array('class' => 'col-md-3 control-label')); !!}
+                                {{ html()->label('status', trans('themes.statusLabel'))->class('col-md-3 control-label') }}
                                 <div class="col-md-9">
                                     <label class="switch checked" for="status">
                                         <span class="active"><i class="fa fa-toggle-on fa-2x"></i> {{ trans('themes.statusEnabled') }}</span>
@@ -52,10 +54,10 @@
                             </div>
 
                             <div class="form-group has-feedback row {{ $errors->has('name') ? ' has-error ' : '' }}">
-                                {!! Form::label('name', trans('themes.nameLabel'), array('class' => 'col-md-3 control-label')); !!}
+                                {{ html()->label('name', trans('themes.nameLabel'))->class('col-md-3 control-label') }}
                                 <div class="col-md-9">
                                     <div class="input-group">
-                                        {!! Form::text('name', null, array('id' => 'name', 'class' => 'form-control', 'placeholder' => trans('themes.namePlaceholder'))) !!}
+                                        {{ html()->text('name')->id('name')->class('form-control')->placeholder(trans('themes.namePlaceholder')) }}
                                         <div class="input-group-append">
                                             <label for="name" class="input-group-text">
                                                 <i class="fa fa-fw fa-pencil" aria-hidden="true"></i>
@@ -71,10 +73,10 @@
                             </div>
 
                             <div class="form-group has-feedback row {{ $errors->has('link') ? ' has-error ' : '' }}">
-                                {!! Form::label('link', trans('themes.linkLabel'), array('class' => 'col-md-3 control-label')); !!}
+                                {{ html()->label('link', trans('themes.linkLabel'))->class('col-md-3 control-label') }}
                                 <div class="col-md-9">
                                     <div class="input-group">
-                                        {!! Form::text('link', null, array('id' => 'link', 'class' => 'form-control', 'placeholder' => trans('themes.linkPlaceholder'))) !!}
+                                        {{ html()->text('link')->id('link')->class('form-control')->placeholder(trans('themes.linkPlaceholder')) }}
                                         <div class="input-group-append">
                                             <label for="link" class="input-group-text">
                                                 <i class="fa fa-fw fa-link fa-rotate-90" aria-hidden="true"></i>
@@ -90,10 +92,10 @@
                             </div>
 
                             <div class="form-group has-feedback row {{ $errors->has('notes') ? ' has-error ' : '' }}">
-                                {!! Form::label('notes', trans('themes.notesLabel') , array('class' => 'col-md-3 control-label')); !!}
+                                {{ html()->label('notes', trans('themes.notesLabel'))->class('col-md-3 control-label') }}
                                 <div class="col-md-9">
                                     <div class="input-group">
-                                        {!! Form::textarea('notes', old('notes'), array('id' => 'notes', 'class' => 'form-control', 'placeholder' => trans('themes.notesPlaceholder'))) !!}
+                                        {{ html()->textarea('notes')->id('notes')->class('form-control')->placeholder(trans('themes.notesPlaceholder')) }}
                                         <div class="input-group-append">
                                             <label for="notes" class="input-group-text">
                                                 <i class="fa fa-fw fa-pencil" aria-hidden="true"></i>
@@ -113,12 +115,14 @@
                         <div class="card-footer">
                             <div class="row">
                                 <div class="col-sm-6 offset-sm-6">
-                                    {!! Form::button('<i class="fa fa-plus" aria-hidden="true"></i>&nbsp;' . trans('themes.btnAddTheme'), array('class' => 'btn btn-success btn-block mb-0','type' => 'submit', )) !!}
+                                    {{ html()->button('<i class="fa fa-plus" aria-hidden="true"></i>&nbsp;' . trans('themes.btnAddTheme'))
+                                        ->class('btn btn-success btn-block mb-0')
+                                        ->type('submit') }}
                                 </div>
                             </div>
                         </div>
 
-                    {!! Form::close() !!}
+                    {{ html()->form()->close() }}
 
                 </div>
             </div>

--- a/resources/views/themesmanagement/edit-theme.blade.php
+++ b/resources/views/themesmanagement/edit-theme.blade.php
@@ -47,14 +47,17 @@
                         </div>
                     </div>
 
-                    {!! Form::model($theme, array('action' => array('ThemesManagementController@update', $theme->id), 'method' => 'PUT')) !!}
+                    {{ html()->model($theme) }}
+                    {{ html()->form('POST', action([App\Http\Controllers\ThemesManagementController::class, 'update'], $theme->id))
+                            ->open() }}
 
-                        {!! csrf_field() !!}
+                        @csrf
+                        @method('PUT')
 
                         <div class="card-body">
 
                             <div class="form-group has-feedback row {{ $errors->has('status') ? ' has-error ' : '' }} @if($theme->id == 1) disabled @endif ">
-                                {!! Form::label('status', trans('themes.statusLabel'), array('class' => 'col-md-3 control-label')); !!}
+                                {{ html()->label('status', trans('themes.statusLabel'))->class('col-md-3 control-label') }}
                                 <div class="col-md-9">
                                     <label class="switch {{ $themeActive['checked'] }}" for="status">
                                         <span class="active"><i class="fa fa-toggle-on fa-2x"></i> {{ trans('themes.statusEnabled') }}</span>
@@ -72,10 +75,10 @@
                             </div>
 
                             <div class="form-group has-feedback row {{ $errors->has('name') ? ' has-error ' : '' }}">
-                                {!! Form::label('name', trans('themes.nameLabel'), array('class' => 'col-md-3 control-label')); !!}
+                                {{ html()->label('name', trans('themes.nameLabel'))->class('col-md-3 control-label') }}
                                 <div class="col-md-9">
                                     <div class="input-group">
-                                        {!! Form::text('name', $theme->name, array('id' => 'name', 'class' => 'form-control', 'placeholder' => trans('themes.namePlaceholder'))) !!}
+                                        {{ html()->text('name')->id('name')->class('form-control')->placeholder(trans('themes.namePlaceholder')) }}
                                         <div class="input-group-append">
                                             <label for="name" class="input-group-text">
                                                 <i class="fa fa-fw fa-pencil" aria-hidden="true"></i>
@@ -91,10 +94,10 @@
                             </div>
 
                             <div class="form-group has-feedback row {{ $errors->has('link') ? ' has-error ' : '' }}">
-                                {!! Form::label('link', trans('themes.linkLabel'), array('class' => 'col-md-3 control-label')); !!}
+                                {{ html()->label('link', trans('themes.linkLabel'))->class('col-md-3 control-label') }}
                                 <div class="col-md-9">
                                     <div class="input-group">
-                                        {!! Form::text('link', $theme->link, array('id' => 'link', 'class' => 'form-control', 'placeholder' => trans('themes.linkPlaceholder'))) !!}
+                                        {{ html()->text('link')->id('link')->class('form-control')->placeholder(trans('themes.linkPlaceholder')) }}
                                         <div class="input-group-append">
                                             <label for="link" class="input-group-text">
                                                 <i class="fa fa-fw fa-link fa-rotate-90" aria-hidden="true"></i>
@@ -110,10 +113,10 @@
                             </div>
 
                             <div class="form-group has-feedback row {{ $errors->has('notes') ? ' has-error ' : '' }}">
-                                {!! Form::label('notes', trans('themes.notesLabel') , array('class' => 'col-md-3 control-label')); !!}
+                                {{ html()->label('notes', trans('themes.notesLabel'))->class('col-md-3 control-label') }}
                                 <div class="col-md-9">
                                     <div class="input-group">
-                                        {!! Form::textarea('notes', old('notes'), array('id' => 'notes', 'class' => 'form-control', 'placeholder' => trans('themes.notesPlaceholder'))) !!}
+                                        {{ html()->textarea('notes')->id('notes')->class('form-control')->placeholder(trans('themes.notesPlaceholder')) }}
                                         <div class="input-group-append">
                                             <label for="notes" class="input-group-text">
                                                 <i class="fa fa-fw fa-pencil" aria-hidden="true"></i>
@@ -133,12 +136,19 @@
                         <div class="card-footer">
                             <div class="row">
                                 <div class="col-sm-6">
-                                    {!! Form::button('<i class="fa fa-fw fa-save" aria-hidden="true"></i> ' . trans('themes.editSave'), array('class' => 'btn btn-success btn-block mb-0 btn-save','type' => 'button', 'data-toggle' => 'modal', 'data-target' => '#confirmSave', 'data-title' => trans('modals.edit_user__modal_text_confirm_title'), 'data-message' => trans('modals.edit_user__modal_text_confirm_message'))) !!}
+                                    {{ html()->button('<i class="fa fa-fw fa-save" aria-hidden="true"></i> ' . trans('themes.editSave'))
+                                        ->class('btn btn-success btn-block mb-0 btn-save')
+                                        ->type('button')
+                                        ->attribute('data-toggle', 'modal')
+                                        ->attribute('data-target', '#confirmSave')
+                                        ->attribute('data-title', trans('modals.edit_user__modal_text_confirm_title'))
+                                        ->attribute('data-message', trans('modals.edit_user__modal_text_confirm_message')) }}
                                 </div>
                             </div>
                         </div>
 
-                    {!! Form::close() !!}
+                    {{ html()->form()->close() }}
+                    {{ html()->endModel() }}
 
                 </div>
             </div>

--- a/resources/views/themesmanagement/show-theme.blade.php
+++ b/resources/views/themesmanagement/show-theme.blade.php
@@ -105,10 +105,19 @@
                                 <i class="fa fa-pencil fa-fw" aria-hidden="true"></i> Edit<span class="hidden-sm"> this</span><span class="hidden-sm"> Theme</span>
                             </a>
                         </div>
-                        {!! Form::open(array('url' => 'themes/' . $theme->id, 'class' => 'col-sm-6 mb-2')) !!}
-                            {!! Form::hidden('_method', 'DELETE') !!}
-                            {!! Form::button('<i class="fa fa-trash-o fa-fw" aria-hidden="true"></i> Delete<span class="hidden-sm"> this</span><span class="hidden-sm"> Theme</span>', array('class' => 'btn btn-danger btn-block btn-flat','type' => 'button', 'data-toggle' => 'modal', 'data-target' => '#confirmDelete', 'data-title' => trans('themes.confirmDeleteHdr'), 'data-message' => trans('themes.confirmDelete'))) !!}
-                        {!! Form::close() !!}
+                        {{ html()->form('POST', url('themes/' . $theme->id))
+                                ->class('col-sm-6 mb-2')
+                                ->open() }}
+                            @csrf
+                            @method('DELETE')
+                            {{ html()->button('<i class="fa fa-trash-o fa-fw" aria-hidden="true"></i> Delete<span class="hidden-sm"> this</span><span class="hidden-sm"> Theme</span>')
+                                ->class('btn btn-danger btn-block btn-flat')
+                                ->type('button')
+                                ->attribute('data-toggle', 'modal')
+                                ->attribute('data-target', '#confirmDelete')
+                                ->attribute('data-title', trans('themes.confirmDeleteHdr'))
+                                ->attribute('data-message', trans('themes.confirmDelete')) }}
+                        {{ html()->form()->close() }}
                     </div>
                 </div>
             </div>

--- a/resources/views/themesmanagement/show-themes.blade.php
+++ b/resources/views/themesmanagement/show-themes.blade.php
@@ -113,10 +113,21 @@
                                         </a>
                                     </td>
                                     <td>
-                                        {!! Form::open(array('url' => 'themes/' . $aTheme->id, 'class' => '', 'data-toggle' => 'tooltip', 'title' => 'Delete Theme')) !!}
-                                            {!! Form::hidden('_method', 'DELETE') !!}
-                                            {!! Form::button('<i class="fa fa-trash-o fa-fw" aria-hidden="true"></i> <span class="sr-only">Delete Theme</span>', array('class' => 'btn btn-danger btn-sm','type' => 'button', 'style' =>'width: 100%;' ,'data-toggle' => 'modal', 'data-target' => '#confirmDelete', 'data-title' => trans('themes.confirmDeleteHdr'), 'data-message' => trans('themes.confirmDelete'))) !!}
-                                        {!! Form::close() !!}
+                                        {{ html()->form('POST', url('themes/' . $aTheme->id))
+                                                ->attribute('data-toggle', 'tooltip')
+                                                ->attribute('title', 'Delete Theme')
+                                                ->open() }}
+                                            @csrf
+                                            @method('DELETE')
+                                            {{ html()->button('<i class="fa fa-trash-o fa-fw" aria-hidden="true"></i> <span class="sr-only">Delete Theme</span>')
+                                                ->class('btn btn-danger btn-sm')
+                                                ->type('button')
+                                                ->style('width: 100%;')
+                                                ->attribute('data-toggle', 'modal')
+                                                ->attribute('data-target', '#confirmDelete')
+                                                ->attribute('data-title', trans('themes.confirmDeleteHdr'))
+                                                ->attribute('data-message', trans('themes.confirmDelete')) }}
+                                        {{ html()->form()->close() }}
                                     </td>
                                 </tr>
                             @endforeach

--- a/resources/views/usersmanagement/create-user.blade.php
+++ b/resources/views/usersmanagement/create-user.blade.php
@@ -26,15 +26,18 @@
                     </div>
 
                     <div class="card-body">
-                        {!! Form::open(array('route' => 'users.store', 'method' => 'POST', 'role' => 'form', 'class' => 'needs-validation')) !!}
+                        {{ html()->form('POST', route('users.store'))
+                                ->attribute('role', 'form')
+                                ->class('needs-validation')
+                                ->open() }}
 
-                            {!! csrf_field() !!}
+                            @csrf
 
                             <div class="form-group has-feedback row {{ $errors->has('email') ? ' has-error ' : '' }}">
-                                {!! Form::label('email', trans('forms.create_user_label_email'), array('class' => 'col-md-3 control-label')); !!}
+                                {{ html()->label('email', trans('forms.create_user_label_email'))->class('col-md-3 control-label') }}
                                 <div class="col-md-9">
                                     <div class="input-group">
-                                        {!! Form::text('email', NULL, array('id' => 'email', 'class' => 'form-control', 'placeholder' => trans('forms.create_user_ph_email'))) !!}
+                                        {{ html()->email('email')->id('email')->class('form-control')->placeholder(trans('forms.create_user_ph_email')) }}
                                         <div class="input-group-append">
                                             <label for="email" class="input-group-text">
                                                 <i class="fa fa-fw {{ trans('forms.create_user_icon_email') }}" aria-hidden="true"></i>
@@ -50,10 +53,10 @@
                             </div>
 
                             <div class="form-group has-feedback row {{ $errors->has('name') ? ' has-error ' : '' }}">
-                                {!! Form::label('name', trans('forms.create_user_label_username'), array('class' => 'col-md-3 control-label')); !!}
+                                {{ html()->label('name', trans('forms.create_user_label_username'))->class('col-md-3 control-label') }}
                                 <div class="col-md-9">
                                     <div class="input-group">
-                                        {!! Form::text('name', NULL, array('id' => 'name', 'class' => 'form-control', 'placeholder' => trans('forms.create_user_ph_username'))) !!}
+                                        {{ html()->text('name')->id('name')->class('form-control')->placeholder(trans('forms.create_user_ph_username')) }}
                                         <div class="input-group-append">
                                             <label class="input-group-text" for="name">
                                                 <i class="fa fa-fw {{ trans('forms.create_user_icon_username') }}" aria-hidden="true"></i>
@@ -69,10 +72,10 @@
                             </div>
 
                             <div class="form-group has-feedback row {{ $errors->has('first_name') ? ' has-error ' : '' }}">
-                                {!! Form::label('first_name', trans('forms.create_user_label_firstname'), array('class' => 'col-md-3 control-label')); !!}
+                                {{ html()->label('first_name', trans('forms.create_user_label_firstname'))->class('col-md-3 control-label') }}
                                 <div class="col-md-9">
                                     <div class="input-group">
-                                        {!! Form::text('first_name', NULL, array('id' => 'first_name', 'class' => 'form-control', 'placeholder' => trans('forms.create_user_ph_firstname'))) !!}
+                                        {{ html()->text('first_name')->id('first_name')->class('form-control')->placeholder(trans('forms.create_user_ph_firstname')) }}
                                         <div class="input-group-append">
                                             <label class="input-group-text" for="first_name">
                                                 <i class="fa fa-fw {{ trans('forms.create_user_icon_firstname') }}" aria-hidden="true"></i>
@@ -88,10 +91,10 @@
                             </div>
 
                             <div class="form-group has-feedback row {{ $errors->has('last_name') ? ' has-error ' : '' }}">
-                                {!! Form::label('last_name', trans('forms.create_user_label_lastname'), array('class' => 'col-md-3 control-label')); !!}
+                                {{ html()->label('last_name', trans('forms.create_user_label_lastname'))->class('col-md-3 control-label') }}
                                 <div class="col-md-9">
                                     <div class="input-group">
-                                        {!! Form::text('last_name', NULL, array('id' => 'last_name', 'class' => 'form-control', 'placeholder' => trans('forms.create_user_ph_lastname'))) !!}
+                                        {{ html()->text('last_name')->id('last_name')->class('form-control')->placeholder(trans('forms.create_user_ph_lastname')) }}
                                         <div class="input-group-append">
                                             <label class="input-group-text" for="last_name">
                                                 <i class="fa fa-fw {{ trans('forms.create_user_icon_lastname') }}" aria-hidden="true"></i>
@@ -107,7 +110,7 @@
                             </div>
 
                             <div class="form-group has-feedback row {{ $errors->has('role') ? ' has-error ' : '' }}">
-                                {!! Form::label('role', trans('forms.create_user_label_role'), array('class' => 'col-md-3 control-label')); !!}
+                                {{ html()->label('role', trans('forms.create_user_label_role'))->class('col-md-3 control-label') }}
                                 <div class="col-md-9">
                                     <div class="input-group">
                                         <select class="custom-select form-control" name="role" id="role">
@@ -133,10 +136,10 @@
                             </div>
 
                             <div class="form-group has-feedback row {{ $errors->has('password') ? ' has-error ' : '' }}">
-                                {!! Form::label('password', trans('forms.create_user_label_password'), array('class' => 'col-md-3 control-label')); !!}
+                                {{ html()->label('password', trans('forms.create_user_label_password'))->class('col-md-3 control-label') }}
                                 <div class="col-md-9">
                                     <div class="input-group">
-                                        {!! Form::password('password', array('id' => 'password', 'class' => 'form-control ', 'placeholder' => trans('forms.create_user_ph_password'))) !!}
+                                        {{ html()->password('password')->id('password')->class('form-control ')->placeholder(trans('forms.create_user_ph_password')) }}
                                         <div class="input-group-append">
                                             <label class="input-group-text" for="password">
                                                 <i class="fa fa-fw {{ trans('forms.create_user_icon_password') }}" aria-hidden="true"></i>
@@ -151,10 +154,10 @@
                                 </div>
                             </div>
                             <div class="form-group has-feedback row {{ $errors->has('password_confirmation') ? ' has-error ' : '' }}">
-                                {!! Form::label('password_confirmation', trans('forms.create_user_label_pw_confirmation'), array('class' => 'col-md-3 control-label')); !!}
+                                {{ html()->label('password_confirmation', trans('forms.create_user_label_pw_confirmation'))->class('col-md-3 control-label') }}
                                 <div class="col-md-9">
                                     <div class="input-group">
-                                        {!! Form::password('password_confirmation', array('id' => 'password_confirmation', 'class' => 'form-control', 'placeholder' => trans('forms.create_user_ph_pw_confirmation'))) !!}
+                                        {{ html()->password('password_confirmation')->id('password_confirmation')->class('form-control')->placeholder(trans('forms.create_user_ph_pw_confirmation')) }}
                                         <div class="input-group-append">
                                             <label class="input-group-text" for="password_confirmation">
                                                 <i class="fa fa-fw {{ trans('forms.create_user_icon_pw_confirmation') }}" aria-hidden="true"></i>
@@ -168,8 +171,10 @@
                                     @endif
                                 </div>
                             </div>
-                            {!! Form::button(trans('forms.create_user_button_text'), array('class' => 'btn btn-success margin-bottom-1 mb-1 float-right','type' => 'submit' )) !!}
-                        {!! Form::close() !!}
+                            {{ html()->button(trans('forms.create_user_button_text'))
+                                ->class('btn btn-success margin-bottom-1 mb-1 float-right')
+                                ->type('submit') }}
+                        {{ html()->form()->close() }}
                     </div>
 
                 </div>

--- a/resources/views/usersmanagement/edit-user.blade.php
+++ b/resources/views/usersmanagement/edit-user.blade.php
@@ -35,15 +35,19 @@
                         </div>
                     </div>
                     <div class="card-body">
-                        {!! Form::open(array('route' => ['users.update', $user->id], 'method' => 'PUT', 'role' => 'form', 'class' => 'needs-validation')) !!}
+                        {{ html()->form('POST', route('users.update', $user->id))
+                                ->attribute('role', 'form')
+                                ->class('needs-validation')
+                                ->open() }}
 
-                            {!! csrf_field() !!}
+                            @csrf
+                            @method('PUT')
 
                             <div class="form-group has-feedback row {{ $errors->has('name') ? ' has-error ' : '' }}">
-                                {!! Form::label('name', trans('forms.create_user_label_username'), array('class' => 'col-md-3 control-label')); !!}
+                                {{ html()->label('name', trans('forms.create_user_label_username'))->class('col-md-3 control-label') }}
                                 <div class="col-md-9">
                                     <div class="input-group">
-                                        {!! Form::text('name', $user->name, array('id' => 'name', 'class' => 'form-control', 'placeholder' => trans('forms.create_user_ph_username'))) !!}
+                                        {{ html()->text('name')->id('name')->class('form-control')->placeholder(trans('forms.create_user_ph_username')) }}
                                         <div class="input-group-append">
                                             <label class="input-group-text" for="name">
                                                 <i class="fa fa-fw {{ trans('forms.create_user_icon_username') }}" aria-hidden="true"></i>
@@ -59,10 +63,10 @@
                             </div>
 
                             <div class="form-group has-feedback row {{ $errors->has('first_name') ? ' has-error ' : '' }}">
-                                {!! Form::label('first_name', trans('forms.create_user_label_firstname'), array('class' => 'col-md-3 control-label')); !!}
+                                {{ html()->label('first_name', trans('forms.create_user_label_firstname'))->class('col-md-3 control-label') }}
                                 <div class="col-md-9">
                                     <div class="input-group">
-                                        {!! Form::text('first_name', $user->first_name, array('id' => 'first_name', 'class' => 'form-control', 'placeholder' => trans('forms.create_user_ph_firstname'))) !!}
+                                        {{ html()->text('first_name')->id('first_name')->class('form-control')->placeholder(trans('forms.create_user_ph_firstname')) }}
                                         <div class="input-group-append">
                                             <label class="input-group-text" for="first_name">
                                                 <i class="fa fa-fw {{ trans('forms.create_user_icon_firstname') }}" aria-hidden="true"></i>
@@ -78,10 +82,10 @@
                             </div>
 
                             <div class="form-group has-feedback row {{ $errors->has('last_name') ? ' has-error ' : '' }}">
-                                {!! Form::label('last_name', trans('forms.create_user_label_lastname'), array('class' => 'col-md-3 control-label')); !!}
+                                {{ html()->label('last_name', trans('forms.create_user_label_lastname'))->class('col-md-3 control-label') }}
                                 <div class="col-md-9">
                                     <div class="input-group">
-                                        {!! Form::text('last_name', $user->last_name, array('id' => 'last_name', 'class' => 'form-control', 'placeholder' => trans('forms.create_user_ph_lastname'))) !!}
+                                        {{ html()->text('last_name')->id('last_name')->class('form-control')->placeholder(trans('forms.create_user_ph_lastname')) }}
                                         <div class="input-group-append">
                                             <label class="input-group-text" for="last_name">
                                                 <i class="fa fa-fw {{ trans('forms.create_user_icon_lastname') }}" aria-hidden="true"></i>
@@ -97,10 +101,10 @@
                             </div>
 
                             <div class="form-group has-feedback row {{ $errors->has('email') ? ' has-error ' : '' }}">
-                                {!! Form::label('email', trans('forms.create_user_label_email'), array('class' => 'col-md-3 control-label')); !!}
+                                {{ html()->label('email', trans('forms.create_user_label_email'))->class('col-md-3 control-label') }}
                                 <div class="col-md-9">
                                     <div class="input-group">
-                                        {!! Form::text('email', $user->email, array('id' => 'email', 'class' => 'form-control', 'placeholder' => trans('forms.create_user_ph_email'))) !!}
+                                        {{ html()->email('email')->id('email')->class('form-control')->placeholder(trans('forms.create_user_ph_email')) }}
                                         <div class="input-group-append">
                                             <label for="email" class="input-group-text">
                                                 <i class="fa fa-fw {{ trans('forms.create_user_icon_email') }}" aria-hidden="true"></i>
@@ -117,7 +121,7 @@
 
                             <div class="form-group has-feedback row {{ $errors->has('role') ? ' has-error ' : '' }}">
 
-                                {!! Form::label('role', trans('forms.create_user_label_role'), array('class' => 'col-md-3 control-label')); !!}
+                                {{ html()->label('role', trans('forms.create_user_label_role'))->class('col-md-3 control-label') }}
 
                                 <div class="col-md-9">
                                     <div class="input-group">
@@ -146,11 +150,11 @@
                             <div class="pw-change-container">
                                 <div class="form-group has-feedback row {{ $errors->has('password') ? ' has-error ' : '' }}">
 
-                                    {!! Form::label('password', trans('forms.create_user_label_password'), array('class' => 'col-md-3 control-label')); !!}
+                                    {{ html()->label('password', trans('forms.create_user_label_password'))->class('col-md-3 control-label') }}
 
                                     <div class="col-md-9">
                                         <div class="input-group">
-                                            {!! Form::password('password', array('id' => 'password', 'class' => 'form-control ', 'placeholder' => trans('forms.create_user_ph_password'))) !!}
+                                            {{ html()->password('password')->id('password')->class('form-control ')->placeholder(trans('forms.create_user_ph_password')) }}
                                             <div class="input-group-append">
                                                 <label class="input-group-text" for="password">
                                                     <i class="fa fa-fw {{ trans('forms.create_user_icon_password') }}" aria-hidden="true"></i>
@@ -166,11 +170,11 @@
                                 </div>
                                 <div class="form-group has-feedback row {{ $errors->has('password_confirmation') ? ' has-error ' : '' }}">
 
-                                    {!! Form::label('password_confirmation', trans('forms.create_user_label_pw_confirmation'), array('class' => 'col-md-3 control-label')); !!}
+                                    {{ html()->label('password_confirmation', trans('forms.create_user_label_pw_confirmation'))->class('col-md-3 control-label') }}
 
                                     <div class="col-md-9">
                                         <div class="input-group">
-                                            {!! Form::password('password_confirmation', array('id' => 'password_confirmation', 'class' => 'form-control', 'placeholder' => trans('forms.create_user_ph_pw_confirmation'))) !!}
+                                            {{ html()->password('password_confirmation')->id('password_confirmation')->class('form-control')->placeholder(trans('forms.create_user_ph_pw_confirmation')) }}
                                             <div class="input-group-append">
                                                 <label class="input-group-text" for="password_confirmation">
                                                     <i class="fa fa-fw {{ trans('forms.create_user_icon_pw_confirmation') }}" aria-hidden="true"></i>
@@ -193,10 +197,16 @@
                                     </a>
                                 </div>
                                 <div class="col-12 col-sm-6">
-                                    {!! Form::button(trans('forms.save-changes'), array('class' => 'btn btn-success btn-block margin-bottom-1 mt-3 mb-2 btn-save','type' => 'button', 'data-toggle' => 'modal', 'data-target' => '#confirmSave', 'data-title' => trans('modals.edit_user__modal_text_confirm_title'), 'data-message' => trans('modals.edit_user__modal_text_confirm_message'))) !!}
+                                    {{ html()->button(trans('forms.save-changes'))
+                                        ->class('btn btn-success btn-block margin-bottom-1 mt-3 mb-2 btn-save')
+                                        ->type('button')
+                                        ->attribute('data-toggle', 'modal')
+                                        ->attribute('data-target', '#confirmSave')
+                                        ->attribute('data-title', trans('modals.edit_user__modal_text_confirm_title'))
+                                        ->attribute('data-message', trans('modals.edit_user__modal_text_confirm_message')) }}
                                 </div>
                             </div>
-                        {!! Form::close() !!}
+                        {{ html()->form()->close() }}
                     </div>
 
                 </div>

--- a/resources/views/usersmanagement/show-deleted-user.blade.php
+++ b/resources/views/usersmanagement/show-deleted-user.blade.php
@@ -46,17 +46,41 @@
                                     {{ $user->first_name }} {{ $user->last_name }}
                                     </strong>
                                     <br />
-                                    {{ HTML::mailto($user->email, $user->email) }}
+                                    {{ html()->mailto($user->email, $user->email) }}
                                 </p>
                                 @if ($user->profile)
                                 <div class="text-center text-left-tablet mb-4">
-                                    {!! Form::model($user, array('action' => array('SoftDeletesController@update', $user->id), 'method' => 'PUT', 'class' => 'form-inline')) !!}
-                                        {!! Form::button('<i class="fa fa-refresh fa-fw" aria-hidden="true"></i> Restore User', array('class' => 'btn btn-success btn-block btn-sm mt-1 mb-1', 'type' => 'submit', 'data-toggle' => 'tooltip', 'title' => 'Restore User')) !!}
-                                        {!! Form::close() !!}
-                                        {!! Form::model($user, array('action' => array('SoftDeletesController@destroy', $user->id), 'method' => 'DELETE', 'class' => 'form-inline', 'data-toggle' => 'tooltip', 'title' => 'Permanently Delete User')) !!}
-                                        {!! Form::hidden('_method', 'DELETE') !!}
-                                        {!! Form::button('<i class="fa fa-user-times fa-fw" aria-hidden="true"></i> Delete User', array('class' => 'btn btn-danger btn-sm ','type' => 'button', 'style' =>'width: 100%;' ,'data-toggle' => 'modal', 'data-target' => '#confirmDelete', 'data-title' => 'Permanently Delete User', 'data-message' => 'Are you sure you want to permanently delete this user?')) !!}
-                                    {!! Form::close() !!}
+                                    {{ html()->model($user) }}
+                                    {{ html()->form('POST', action([App\Http\Controllers\SoftDeletesController::class, 'update'], $user->id))
+                                        ->class('form-inline')
+                                        ->open() }}
+                                        @csrf
+                                        @method('PUT')
+                                        {{ html()->button('<i class="fa fa-refresh fa-fw" aria-hidden="true"></i> Restore User')
+                                            ->class('btn btn-success btn-block btn-sm mt-1 mb-1')
+                                            ->type('submit')
+                                            ->attribute('data-toggle', 'tooltip')
+                                            ->attribute('title', 'Restore User') }}
+                                    {{ html()->form()->close() }}
+                                    {{ html()->endModel() }}
+                                    {{ html()->model($user) }}
+                                    {{ html()->form('POST', action([App\Http\Controllers\SoftDeletesController::class, 'destroy'], $user->id))
+                                        ->class('form-inline')
+                                        ->attribute('data-toggle', 'tooltip')
+                                        ->attribute('title', 'Permanently Delete User')
+                                        ->open() }}
+                                        @csrf
+                                        @method('DELETE')
+                                        {{ html()->button('<i class="fa fa-user-times fa-fw" aria-hidden="true"></i> Delete User')
+                                            ->class('btn btn-danger btn-sm ')
+                                            ->type('button')
+                                            ->style('width: 100%;')
+                                            ->attribute('data-toggle', 'modal')
+                                            ->attribute('data-target', '#confirmDelete')
+                                            ->attribute('data-title', 'Permanently Delete User')
+                                            ->attribute('data-message', 'Are you sure you want to permanently delete this user?') }}
+                                    {{ html()->form()->close() }}
+                                    {{ html()->endModel() }}
                                 </div>
                                 @endif
                             </div>

--- a/resources/views/usersmanagement/show-deleted-users.blade.php
+++ b/resources/views/usersmanagement/show-deleted-users.blade.php
@@ -108,9 +108,19 @@
                                                 <td class="hidden-xs">{{$user->deleted_at}}</td>
                                                 <td class="hidden-xs">{{$user->deleted_ip_address}}</td>
                                                 <td>
-                                                    {!! Form::model($user, array('action' => array('SoftDeletesController@update', $user->id), 'method' => 'PUT', 'data-toggle' => 'tooltip')) !!}
-                                                        {!! Form::button('<i class="fa fa-refresh" aria-hidden="true"></i>', array('class' => 'btn btn-success btn-block btn-sm', 'type' => 'submit', 'data-toggle' => 'tooltip', 'title' => 'Restore User')) !!}
-                                                    {!! Form::close() !!}
+                                                    {{ html()->model($user) }}
+                                                    {{ html()->form('POST', action([App\Http\Controllers\SoftDeletesController::class, 'update'], $user->id))
+                                                            ->attribute('data-toggle', 'tooltip')
+                                                            ->open() }}
+                                                        @csrf
+                                                        @method('PUT')
+                                                        {{ html()->button('<i class="fa fa-refresh" aria-hidden="true"></i>')
+                                                            ->class('btn btn-success btn-block btn-sm')
+                                                            ->type('submit')
+                                                            ->attribute('data-toggle', 'tooltip')
+                                                            ->attribute('title', 'Restore User') }}
+                                                    {{ html()->form()->close() }}
+                                                    {{ html()->endModel() }}
                                                 </td>
                                                 <td>
                                                     <a class="btn btn-sm btn-info btn-block" href="{{ URL::to('users/deleted/' . $user->id) }}" data-toggle="tooltip" title="Show User">
@@ -118,10 +128,24 @@
                                                     </a>
                                                 </td>
                                                 <td>
-                                                    {!! Form::model($user, array('action' => array('SoftDeletesController@destroy', $user->id), 'method' => 'DELETE', 'class' => 'inline', 'data-toggle' => 'tooltip', 'title' => 'Destroy User Record')) !!}
-                                                        {!! Form::hidden('_method', 'DELETE') !!}
-                                                        {!! Form::button('<i class="fa fa-user-times" aria-hidden="true"></i>', array('class' => 'btn btn-danger btn-sm inline','type' => 'button', 'style' =>'width: 100%;' ,'data-toggle' => 'modal', 'data-target' => '#confirmDelete', 'data-title' => 'Delete User', 'data-message' => 'Are you sure you want to delete this user ?')) !!}
-                                                    {!! Form::close() !!}
+                                                    {{ html()->model($user) }}
+                                                    {{ html()->form('POST', action([App\Http\Controllers\SoftDeletesController::class, 'destroy'], $user->id))
+                                                            ->class('inline')
+                                                            ->attribute('data-toggle', 'tooltip')
+                                                            ->attribute('title', 'Destroy User Record')
+                                                            ->open() }}
+                                                        @csrf
+                                                        @method('DELETE')
+                                                        {{ html()->button('<i class="fa fa-user-times" aria-hidden="true"></i>')
+                                                            ->class('btn btn-danger btn-sm inline')
+                                                            ->type('button')
+                                                            ->style('width: 100%;')
+                                                            ->attribute('data-toggle', 'modal')
+                                                            ->attribute('data-target', '#confirmDelete')
+                                                            ->attribute('data-title', 'Delete User')
+                                                            ->attribute('data-message', 'Are you sure you want to delete this user ?') }}
+                                                    {{ html()->form()->close() }}
+                                                    {{ html()->endModel() }}
                                                 </td>
                                             </tr>
                                         @endforeach

--- a/resources/views/usersmanagement/show-user.blade.php
+++ b/resources/views/usersmanagement/show-user.blade.php
@@ -48,7 +48,7 @@
                   @if($user->email)
                     <br />
                     <span class="text-center" data-toggle="tooltip" data-placement="top" title="{{ trans('usersmanagement.tooltips.email-user', ['user' => $user->email]) }}">
-                      {{ Html::mailto($user->email, $user->email) }}
+                      {{ html()->mailto($user->email, $user->email) }}
                     </span>
                   @endif
                 </p>
@@ -60,10 +60,22 @@
                     <a href="/users/{{$user->id}}/edit" class="btn btn-sm btn-warning" data-toggle="tooltip" data-placement="top" title="{{ trans('usersmanagement.editUser') }}">
                       <i class="fa fa-pencil fa-fw" aria-hidden="true"></i> <span class="hidden-xs hidden-sm hidden-md"> {{ trans('usersmanagement.editUser') }} </span>
                     </a>
-                    {!! Form::open(array('url' => 'users/' . $user->id, 'class' => 'form-inline', 'data-toggle' => 'tooltip', 'data-placement' => 'right', 'title' => trans('usersmanagement.deleteUser'))) !!}
-                      {!! Form::hidden('_method', 'DELETE') !!}
-                      {!! Form::button('<i class="fa fa-trash-o fa-fw" aria-hidden="true"></i> <span class="hidden-xs hidden-sm hidden-md">' . trans('usersmanagement.deleteUser') . '</span>' , array('class' => 'btn btn-danger btn-sm','type' => 'button', 'data-toggle' => 'modal', 'data-target' => '#confirmDelete', 'data-title' => 'Delete User', 'data-message' => 'Are you sure you want to delete this user?')) !!}
-                    {!! Form::close() !!}
+                    {{ html()->form('POST', url('users/' . $user->id))
+                        ->class('form-inline')
+                        ->attribute('data-toggle', 'tooltip')
+                        ->attribute('data-placement', 'right')
+                        ->attribute('title', trans('usersmanagement.deleteUser'))
+                        ->open() }}
+                      @csrf
+                      @method('DELETE')
+                      {{ html()->button('<i class="fa fa-trash-o fa-fw" aria-hidden="true"></i> <span class="hidden-xs hidden-sm hidden-md">' . trans('usersmanagement.deleteUser') . '</span>')
+                        ->class('btn btn-danger btn-sm')
+                        ->type('button')
+                        ->attribute('data-toggle', 'modal')
+                        ->attribute('data-target', '#confirmDelete')
+                        ->attribute('data-title', 'Delete User')
+                        ->attribute('data-message', 'Are you sure you want to delete this user?') }}
+                    {{ html()->form()->close() }}
                   </div>
                 @endif
               </div>

--- a/resources/views/usersmanagement/show-users.blade.php
+++ b/resources/views/usersmanagement/show-users.blade.php
@@ -110,10 +110,21 @@
                                             <td class="hidden-sm hidden-xs hidden-md">{{$user->created_at}}</td>
                                             <td class="hidden-sm hidden-xs hidden-md">{{$user->updated_at}}</td>
                                             <td>
-                                                {!! Form::open(array('url' => 'users/' . $user->id, 'class' => '', 'data-toggle' => 'tooltip', 'title' => 'Delete')) !!}
-                                                    {!! Form::hidden('_method', 'DELETE') !!}
-                                                    {!! Form::button(trans('usersmanagement.buttons.delete'), array('class' => 'btn btn-danger btn-sm','type' => 'button', 'style' =>'width: 100%;' ,'data-toggle' => 'modal', 'data-target' => '#confirmDelete', 'data-title' => 'Delete User', 'data-message' => 'Are you sure you want to delete this user ?')) !!}
-                                                {!! Form::close() !!}
+                                                {{ html()->form('POST', url('users/' . $user->id))
+                                                        ->attribute('data-toggle', 'tooltip')
+                                                        ->attribute('title', 'Delete')
+                                                        ->open() }}
+                                                    @csrf
+                                                    @method('DELETE')
+                                                    {{ html()->button(trans('usersmanagement.buttons.delete'))
+                                                        ->class('btn btn-danger btn-sm')
+                                                        ->type('button')
+                                                        ->style('width: 100%;')
+                                                        ->attribute('data-toggle', 'modal')
+                                                        ->attribute('data-target', '#confirmDelete')
+                                                        ->attribute('data-title', 'Delete User')
+                                                        ->attribute('data-message', 'Are you sure you want to delete this user ?') }}
+                                                {{ html()->form()->close() }}
                                             </td>
                                             <td>
                                                 <a class="btn btn-sm btn-success btn-block" href="{{ URL::to('users/' . $user->id) }}" data-toggle="tooltip" title="Show">

--- a/resources/views/vendor/forms/create-new.blade.php
+++ b/resources/views/vendor/forms/create-new.blade.php
@@ -1,17 +1,17 @@
-{!! Form::open([
-    'route' => 'laravelblocker::blocker.store',
-    'method' => 'POST',
-    'role' => 'form',
-    'class' => 'needs-validation'
-]) !!}
-    {!! csrf_field() !!}
+{{ html()->form('POST', route('laravelblocker::blocker.store'))
+    ->attribute('role', 'form')
+    ->class('needs-validation')
+    ->open() }}
+    @csrf
     @include('laravelblocker::forms.partials.item-type-select')
     @include('laravelblocker::forms.partials.item-value-input')
     @include('laravelblocker::forms.partials.item-blocked-user-select')
     @include('laravelblocker::forms.partials.item-note-input')
     <div class="row">
         <div class="col-sm-9 offset-sm-3">
-                {!! Form::button(trans('laravelblocker::laravelblocker.buttons.create-larger'), array('class' => 'btn btn-success btn-block margin-bottom-1 mb-1 float-right','type' => 'submit' )) !!}
+                {{ html()->button(trans('laravelblocker::laravelblocker.buttons.create-larger'))
+                    ->class('btn btn-success btn-block margin-bottom-1 mb-1 float-right')
+                    ->type('submit') }}
         </div>
     </div>
-{!! Form::close() !!}
+{{ html()->form()->close() }}

--- a/resources/views/vendor/forms/delete-full.blade.php
+++ b/resources/views/vendor/forms/delete-full.blade.php
@@ -1,13 +1,11 @@
-{!! Form::open([
-    'route' => ['laravelblocker::blocker.destroy', $item->id],
-    'method' => 'DELETE',
-    'accept-charset' => 'UTF-8',
-    'data-toggle' => 'tooltip',
-    'title' => trans('laravelblocker::laravelblocker.tooltips.delete')
-]) !!}
-    {!! Form::hidden("_method", "DELETE") !!}
-    {!! csrf_field() !!}
+{{ html()->form('POST', route('laravelblocker::blocker.destroy', $item->id))
+    ->attribute('accept-charset', 'UTF-8')
+    ->attribute('data-toggle', 'tooltip')
+    ->attribute('title', trans('laravelblocker::laravelblocker.tooltips.delete'))
+    ->open() }}
+    @csrf
+    @method('DELETE')
     <button class="btn btn-danger btn-block edit-form-delete" type="button" style="width: 100%;" data-toggle="modal" data-target="#confirmDelete" data-title="{{ trans('laravelblocker::laravelblocker.modals.delete_blocked_title') }}" data-message="{!! trans("laravelblocker::laravelblocker.modals.delete_blocked_message", ["blocked" => $item->value]) !!}">
         {!! trans("laravelblocker::laravelblocker.buttons.delete-larger") !!}
     </button>
-{!! Form::close() !!}
+{{ html()->form()->close() }}

--- a/resources/views/vendor/forms/delete-item.blade.php
+++ b/resources/views/vendor/forms/delete-item.blade.php
@@ -1,13 +1,11 @@
-{!! Form::open([
-    'route' => ['laravelblocker::blocker.destroy', $item->id],
-    'method' => 'DELETE',
-    'accept-charset' => 'UTF-8',
-    'data-toggle' => 'tooltip',
-    'title' => trans('laravelblocker::laravelblocker.tooltips.delete')
-]) !!}
-    {!! Form::hidden("_method", "DELETE") !!}
-    {!! csrf_field() !!}
+{{ html()->form('POST', route('laravelblocker::blocker.destroy', $item->id))
+    ->attribute('accept-charset', 'UTF-8')
+    ->attribute('data-toggle', 'tooltip')
+    ->attribute('title', trans('laravelblocker::laravelblocker.tooltips.delete'))
+    ->open() }}
+    @csrf
+    @method('DELETE')
     <button class="btn btn-danger btn-sm" type="button" style="width: 100%;" data-toggle="modal" data-target="#confirmDelete" data-title="Delete Blocked Item" data-message="{!! trans("laravelblocker::laravelblocker.modals.delete_blocked_message", ["blocked" => $item->value]) !!}">
         {!! trans("laravelblocker::laravelblocker.buttons.delete-larger") !!}
     </button>
-{!! Form::close() !!}
+{{ html()->form()->close() }}

--- a/resources/views/vendor/forms/delete-sm.blade.php
+++ b/resources/views/vendor/forms/delete-sm.blade.php
@@ -1,13 +1,11 @@
-{!! Form::open([
-    'route' => ['laravelblocker::blocker.destroy', $blockedItem->id],
-    'method' => 'DELETE',
-    'accept-charset' => 'UTF-8',
-    'data-toggle' => 'tooltip',
-    'title' => trans('laravelblocker::laravelblocker.tooltips.delete')
-]) !!}
-    {!! Form::hidden("_method", "DELETE") !!}
-    {!! csrf_field() !!}
+{{ html()->form('POST', route('laravelblocker::blocker.destroy', $blockedItem->id))
+    ->attribute('accept-charset', 'UTF-8')
+    ->attribute('data-toggle', 'tooltip')
+    ->attribute('title', trans('laravelblocker::laravelblocker.tooltips.delete'))
+    ->open() }}
+    @csrf
+    @method('DELETE')
     <button class="btn btn-danger btn-sm btn-block" type="button" style="width: 100%;" data-toggle="modal" data-target="#confirmDelete" data-title="Delete Blocked Item" data-message="{!! trans("laravelblocker::laravelblocker.modals.delete_blocked_message", ["blocked" => $blockedItem->value]) !!}">
         {!! trans("laravelblocker::laravelblocker.buttons.delete") !!}
     </button>
-{!! Form::close() !!}
+{{ html()->form()->close() }}

--- a/resources/views/vendor/forms/destroy-all.blade.php
+++ b/resources/views/vendor/forms/destroy-all.blade.php
@@ -1,11 +1,9 @@
-{!! Form::open([
-    'route' => 'laravelblocker::destroy-all-blocked',
-    'method' => 'DELETE',
-    'accept-charset' => 'UTF-8'
-]) !!}
-    {!! Form::hidden("_method", "DELETE") !!}
-    {!! csrf_field() !!}
+{{ html()->form('POST', route('laravelblocker::destroy-all-blocked'))
+    ->attribute('accept-charset', 'UTF-8')
+    ->open() }}
+    @csrf
+    @method('DELETE')
     <button class="dropdown-item btn pointer" type="button" style="width: 100%;" data-toggle="modal" data-target="#confirmDelete" data-title="{{ trans('laravelblocker::laravelblocker.modals.destroy_all_blocked_title') }}" data-message="{!! trans("laravelblocker::laravelblocker.modals.destroy_all_blocked_message") !!}">
         <i class="fa fa-trash fa-fw" aria-hidden="true"></i> {!! trans_choice("laravelblocker::laravelblocker.buttons.destroy-all", 1, ['count' => $blocked->count()]) !!}
     </button>
-{!! Form::close() !!}
+{{ html()->form()->close() }}

--- a/resources/views/vendor/forms/destroy-full.blade.php
+++ b/resources/views/vendor/forms/destroy-full.blade.php
@@ -1,13 +1,11 @@
-{!! Form::open([
-    'route' => ['laravelblocker::blocker-item-destroy', $item->id],
-    'method' => 'DELETE',
-    'accept-charset' => 'UTF-8',
-    'data-toggle' => 'tooltip',
-    'title' => trans("laravelblocker::laravelblocker.tooltips.destroy_blocked_tooltip")
-]) !!}
-    {!! Form::hidden("_method", "DELETE") !!}
-    {!! csrf_field() !!}
+{{ html()->form('POST', route('laravelblocker::blocker-item-destroy', $item->id))
+    ->attribute('accept-charset', 'UTF-8')
+    ->attribute('data-toggle', 'tooltip')
+    ->attribute('title', trans('laravelblocker::laravelblocker.tooltips.destroy_blocked_tooltip'))
+    ->open() }}
+    @csrf
+    @method('DELETE')
     <button class="btn btn-danger btn-block edit-form-destroy" type="button" style="width: 100%;" data-toggle="modal" data-target="#confirmDelete" data-title="{{ trans('laravelblocker::laravelblocker.modals.destroy_blocked_title') }}" data-message="{!! trans("laravelblocker::laravelblocker.modals.destroy_blocked_message", ["blocked" => $item->value]) !!}">
         {!! trans("laravelblocker::laravelblocker.buttons.destroy-larger") !!}
     </button>
-{!! Form::close() !!}
+{{ html()->form()->close() }}

--- a/resources/views/vendor/forms/destroy-sm.blade.php
+++ b/resources/views/vendor/forms/destroy-sm.blade.php
@@ -1,13 +1,11 @@
-{!! Form::open([
-    'route' => ['laravelblocker::blocker-item-destroy', $blockedItem->id],
-    'method' => 'DELETE',
-    'accept-charset' => 'UTF-8',
-    'data-toggle' => 'tooltip',
-    'title' => trans("laravelblocker::laravelblocker.tooltips.destroy_blocked_tooltip")
-]) !!}
-    {!! Form::hidden("_method", "DELETE") !!}
-    {!! csrf_field() !!}
+{{ html()->form('POST', route('laravelblocker::blocker-item-destroy', $blockedItem->id))
+    ->attribute('accept-charset', 'UTF-8')
+    ->attribute('data-toggle', 'tooltip')
+    ->attribute('title', trans('laravelblocker::laravelblocker.tooltips.destroy_blocked_tooltip'))
+    ->open() }}
+    @csrf
+    @method('DELETE')
     <button class="btn btn-danger btn-sm" type="button" style="width: 100%;" data-toggle="modal" data-target="#confirmDelete" data-title="{{ trans("laravelblocker::laravelblocker.modals.destroy_blocked_title") }}" data-message="{!! trans("laravelblocker::laravelblocker.modals.destroy_blocked_message", ["blocked" => $blockedItem->value]) !!}">
         {!! trans("laravelblocker::laravelblocker.buttons.destroy") !!}
     </button>
-{!! Form::close() !!}
+{{ html()->form()->close() }}

--- a/resources/views/vendor/forms/edit-form.blade.php
+++ b/resources/views/vendor/forms/edit-form.blade.php
@@ -1,20 +1,21 @@
-{!! Form::open([
-    'route' => ['laravelblocker::blocker.update', $item->id],
-    'method' => 'PUT',
-    'role' => 'form',
-    'class' => 'needs-validation'
-]) !!}
-    {!! csrf_field() !!}
+{{ html()->form('POST', route('laravelblocker::blocker.update', $item->id))
+    ->attribute('role', 'form')
+    ->class('needs-validation')
+    ->open() }}
+    @csrf
+    @method('PUT')
     @include('laravelblocker::forms.partials.item-type-select')
     @include('laravelblocker::forms.partials.item-value-input')
     @include('laravelblocker::forms.partials.item-blocked-user-select')
     @include('laravelblocker::forms.partials.item-note-input')
     <div class="row">
         <div class="col-sm-6 offset-sm-6 mt-1">
-            {!! Form::button(trans('laravelblocker::laravelblocker.buttons.save-larger'), array('class' => 'btn btn-success btn-block margin-bottom-1 mb-1 float-right','type' => 'submit' )) !!}
+            {{ html()->button(trans('laravelblocker::laravelblocker.buttons.save-larger'))
+                ->class('btn btn-success btn-block margin-bottom-1 mb-1 float-right')
+                ->type('submit') }}
         </div>
     </div>
-{!! Form::close() !!}
+{{ html()->form()->close() }}
 <div class="row">
     <div class="col-sm-6 mt-2 mt-sm-0">
         @include('laravelblocker::forms.delete-full')

--- a/resources/views/vendor/forms/partials/item-blocked-user-select.blade.php
+++ b/resources/views/vendor/forms/partials/item-blocked-user-select.blade.php
@@ -1,5 +1,5 @@
 <div class="form-group has-feedback row">
-    {!! Form::label('userId', trans('laravelblocker::laravelblocker.forms.blockedUserLabel'), array('class' => 'col-md-3 control-label disabled', 'id' => 'blockerUserLabel1')); !!}
+    {{ html()->label('userId', trans('laravelblocker::laravelblocker.forms.blockedUserLabel'))->class('col-md-3 control-label disabled')->id('blockerUserLabel1') }}
     <div class="col-md-9">
         <div class="input-group">
             <select class="{{ $errors->has('userId') ? 'custom-select form-control is-invalid disabled' : 'custom-select form-control disabled' }}" name="userId" id="userId">

--- a/resources/views/vendor/forms/partials/item-note-input.blade.php
+++ b/resources/views/vendor/forms/partials/item-note-input.blade.php
@@ -1,11 +1,17 @@
 <div class="form-group has-feedback row">
-    {!! Form::label('note', trans('laravelblocker::laravelblocker.forms.blockedNoteLabel'), array('class' => 'col-md-3 control-label')); !!}
+    {{ html()->label('note', trans('laravelblocker::laravelblocker.forms.blockedNoteLabel'))->class('col-md-3 control-label') }}
     <div class="col-md-9">
         <div class="input-group">
             @isset($item)
-                {!! Form::textarea('note', $item->note, array('id' => 'note', 'class' => $errors->has('note') ? 'form-control is-invalid ' : 'form-control', 'placeholder' => trans('laravelblocker::laravelblocker.forms.blockedNotePH'))) !!}
+                {{ html()->textarea('note', $item->note ?? null)
+                    ->id('note')
+                    ->class($errors->has('note') ? 'form-control is-invalid ' : 'form-control')
+                    ->placeholder(trans('laravelblocker::laravelblocker.forms.blockedNotePH')) }}
             @else
-                {!! Form::textarea('note', NULL, array('id' => 'note', 'class' => $errors->has('note') ? 'form-control is-invalid ' : 'form-control', 'placeholder' => trans('laravelblocker::laravelblocker.forms.blockedNotePH'))) !!}
+                {{ html()->textarea('note')
+                    ->id('note')
+                    ->class($errors->has('note') ? 'form-control is-invalid ' : 'form-control')
+                    ->placeholder(trans('laravelblocker::laravelblocker.forms.blockedNotePH')) }}
             @endisset
             <div class="input-group-append">
                 <label class="input-group-text" for="note">

--- a/resources/views/vendor/forms/partials/item-type-select.blade.php
+++ b/resources/views/vendor/forms/partials/item-type-select.blade.php
@@ -1,5 +1,5 @@
 <div class="form-group has-feedback row">
-    {!! Form::label('typeId', trans('laravelblocker::laravelblocker.forms.blockedTypeLabel'), array('class' => 'col-md-3 control-label')); !!}
+    {{ html()->label('typeId', trans('laravelblocker::laravelblocker.forms.blockedTypeLabel'))->class('col-md-3 control-label') }}
     <div class="col-md-9">
         <div class="input-group">
             <select class="{{ $errors->has('typeId') ? 'custom-select form-control is-invalid ' : 'custom-select form-control' }}" name="typeId" id="typeId" >

--- a/resources/views/vendor/forms/partials/item-value-input.blade.php
+++ b/resources/views/vendor/forms/partials/item-value-input.blade.php
@@ -1,11 +1,17 @@
 <div class="form-group has-feedback row">
-    {!! Form::label('value', trans('laravelblocker::laravelblocker.forms.blockedValueLabel'), array('class' => 'col-md-3 control-label', 'id' => 'blockerValueLabel1')); !!}
+    {{ html()->label('value', trans('laravelblocker::laravelblocker.forms.blockedValueLabel'))->class('col-md-3 control-label')->id('blockerValueLabel1') }}
     <div class="col-md-9">
         <div class="input-group">
             @isset($item)
-                {!! Form::text('value', $item->value, array('id' => 'value', 'class' => $errors->has('value') ? 'form-control is-invalid ' : 'form-control', 'placeholder' => trans('laravelblocker::laravelblocker.forms.blockedValuePH'))) !!}
+                {{ html()->text('value', $item->value ?? null)
+                    ->id('value')
+                    ->class($errors->has('value') ? 'form-control is-invalid ' : 'form-control')
+                    ->placeholder(trans('laravelblocker::laravelblocker.forms.blockedValuePH')) }}
             @else
-                {!! Form::text('value', NULL, array('id' => 'value', 'class' => $errors->has('value') ? 'form-control is-invalid ' : 'form-control', 'placeholder' => trans('laravelblocker::laravelblocker.forms.blockedValuePH'))) !!}
+                {{ html()->text('value')
+                    ->id('value')
+                    ->class($errors->has('value') ? 'form-control is-invalid ' : 'form-control')
+                    ->placeholder(trans('laravelblocker::laravelblocker.forms.blockedValuePH')) }}
             @endisset
             <div class="input-group-append">
                 <label class="input-group-text" for="value" id="blockerValueLabel2">

--- a/resources/views/vendor/forms/restore-all.blade.php
+++ b/resources/views/vendor/forms/restore-all.blade.php
@@ -1,17 +1,12 @@
-{!! Form::open([
-    'route' => 'laravelblocker::blocker-deleted-restore-all',
-    'method' => 'POST',
-    'accept-charset' => 'UTF-8'
-]) !!}
-    {!! csrf_field() !!}
-    {!! Form::button('
-        <i class="fa fa-fw fa-history" aria-hidden="true"></i> ' . trans_choice('laravelblocker::laravelblocker.buttons.restore-all-blocked', 1, ['count' => $blocked->count()]),
-        [
-            'type' => 'button',
-            'class' => 'btn dropdown-item',
-            'data-toggle' => 'modal',
-            'data-target' => '#confirmRestore',
-            'data-title' => trans('laravelblocker::laravelblocker.modals.resotreAllBlockedTitle'),
-            'data-message' => trans('laravelblocker::laravelblocker.modals.resotreAllBlockedMessage')
-        ]) !!}
-{!! Form::close() !!}
+{{ html()->form('POST', route('laravelblocker::blocker-deleted-restore-all'))
+    ->attribute('accept-charset', 'UTF-8')
+    ->open() }}
+    @csrf
+    {{ html()->button('<i class="fa fa-fw fa-history" aria-hidden="true"></i> ' . trans_choice('laravelblocker::laravelblocker.buttons.restore-all-blocked', 1, ['count' => $blocked->count()]))
+        ->type('button')
+        ->class('btn dropdown-item')
+        ->attribute('data-toggle', 'modal')
+        ->attribute('data-target', '#confirmRestore')
+        ->attribute('data-title', trans('laravelblocker::laravelblocker.modals.resotreAllBlockedTitle'))
+        ->attribute('data-message', trans('laravelblocker::laravelblocker.modals.resotreAllBlockedMessage')) }}
+{{ html()->form()->close() }}

--- a/resources/views/vendor/forms/restore-item.blade.php
+++ b/resources/views/vendor/forms/restore-item.blade.php
@@ -15,21 +15,18 @@
     @endphp
 @endif
 
-{!! Form::open([
-    'route' => ['laravelblocker::blocker-item-restore', $itemId],
-    'method' => 'PUT',
-    'accept-charset' => 'UTF-8',
-    'data-toggle' => 'tooltip',
-    'title' => trans("laravelblocker::laravelblocker.tooltips.restoreItem")
-]) !!}
-    {!! Form::hidden("_method", "PUT") !!}
-    {!! csrf_field() !!}
-    {!! Form::button($itemText, [
-            'type' => 'button',
-            'class' => $itemClasses,
-            'data-toggle' => 'modal',
-            'data-target' => '#confirmRestore',
-            'data-title' => trans('laravelblocker::laravelblocker.modals.resotreBlockedItemTitle'),
-            'data-message' => trans('laravelblocker::laravelblocker.modals.resotreBlockedItemMessage', ['value' => $itemValue])
-        ]) !!}
-{!! Form::close() !!}
+{{ html()->form('POST', route('laravelblocker::blocker-item-restore', $itemId))
+    ->attribute('accept-charset', 'UTF-8')
+    ->attribute('data-toggle', 'tooltip')
+    ->attribute('title', trans('laravelblocker::laravelblocker.tooltips.restoreItem'))
+    ->open() }}
+    @csrf
+    @method('PUT')
+    {{ html()->button($itemText)
+            ->type('button')
+            ->class($itemClasses)
+            ->attribute('data-toggle', 'modal')
+            ->attribute('data-target', '#confirmRestore')
+            ->attribute('data-title', trans('laravelblocker::laravelblocker.modals.resotreBlockedItemTitle'))
+            ->attribute('data-message', trans('laravelblocker::laravelblocker.modals.resotreBlockedItemMessage', ['value' => $itemValue])) }}
+{{ html()->form()->close() }}

--- a/resources/views/vendor/forms/search-blocked.blade.php
+++ b/resources/views/vendor/forms/search-blocked.blade.php
@@ -1,15 +1,17 @@
 <div class="row" id="search_blocked_form">
     <div class="col-sm-8 offset-sm-4 col-md-6 offset-md-6 col-lg-5 offset-lg-7 col-xl-4 offset-xl-8">
-        {!! Form::open([
-            'route' => 'laravelblocker::search-blocked',
-            'method' => 'POST',
-            'role' => 'form',
-            'class' => 'needs-validation',
-            'id' => 'search_blocked'
-        ]) !!}
-            {!! csrf_field() !!}
+        {{ html()->form('POST', route('laravelblocker::search-blocked'))
+            ->attribute('role', 'form')
+            ->class('needs-validation')
+            ->id('search_blocked')
+            ->open() }}
+            @csrf
             <div class="input-group mb-3">
-                {!! Form::text('blocked_search_box', NULL, ['id' => 'blocked_search_box', 'class' => 'form-control', 'placeholder' => trans('laravelblocker::laravelblocker.forms.search-blocked-ph'), 'aria-label' => trans('laravelblocker::forms.search-users-ph'), 'required' => false]) !!}
+                {{ html()->text('blocked_search_box')
+                    ->id('blocked_search_box')
+                    ->class('form-control')
+                    ->placeholder(trans('laravelblocker::laravelblocker.forms.search-blocked-ph'))
+                    ->attribute('aria-label', trans('laravelblocker::forms.search-users-ph')) }}
                 <div class="input-group-append">
                     <a href="#" class="btn btn-warning clear-search" style="display: none;" data-toggle="tooltip" title="{!! trans('laravelblocker::laravelblocker.tooltips.clear-search') !!}">
                         @if(config('laravelblocker.blockerEnableFontAwesomeCDN'))
@@ -24,12 +26,20 @@
                         @endif
                     </a>
                     @if(config('laravelblocker.blockerEnableFontAwesomeCDN'))
-                        {!! Form::button('<i class="fa fas fa-search" aria-hidden="true"></i> <span class="sr-only"> ' . trans('laravelblocker::laravelblocker.tooltips.submit-search') . ' </span>', ['class' => 'btn btn-secondary', 'type' => 'submit', 'data-toggle' => 'tooltip', 'data-placement' => 'bottom', 'title' => trans('laravelblocker::laravelblocker.tooltips.submit-search')]) !!}
+                        {{ html()->button('<i class="fa fas fa-search" aria-hidden="true"></i> <span class="sr-only"> ' . trans('laravelblocker::laravelblocker.tooltips.submit-search') . ' </span>')
+                            ->class('btn btn-secondary')
+                            ->type('submit')
+                            ->attribute('data-toggle', 'tooltip')
+                            ->attribute('data-placement', 'bottom')
+                            ->attribute('title', trans('laravelblocker::laravelblocker.tooltips.submit-search')) }}
                     @else
-                        {!! Form::button(trans('laravelblocker::laravelblocker.tooltips.submit-search'), ['class' => 'btn btn-secondary', 'type' => 'submit', 'title' => trans('laravelblocker::laravelblocker.tooltips.submit-search')]) !!}
+                        {{ html()->button(trans('laravelblocker::laravelblocker.tooltips.submit-search'))
+                            ->class('btn btn-secondary')
+                            ->type('submit')
+                            ->attribute('title', trans('laravelblocker::laravelblocker.tooltips.submit-search')) }}
                     @endif
                 </div>
             </div>
-        {!! Form::close() !!}
+        {{ html()->form()->close() }}
     </div>
 </div>

--- a/resources/views/vendor/laravel2step/twostep/exceeded.blade.php
+++ b/resources/views/vendor/laravel2step/twostep/exceeded.blade.php
@@ -34,7 +34,7 @@
                             <i class="glyphicon glyphicon-home" aria-hidden="true"></i> {{ trans('laravel2step::laravel-verification.returnButton') }}
                         </a>
                         <form id="logout-form" action="{{ route('logout') }}" method="POST" style="display: none;">
-                            {{ csrf_field() }}
+                            @csrf
                         </form>
                     </p>
                 </div>

--- a/resources/views/vendor/modals/confirm-modal.blade.php
+++ b/resources/views/vendor/modals/confirm-modal.blade.php
@@ -26,8 +26,14 @@
                 </p>
             </div>
             <div class="modal-footer">
-                {!! Form::button('<i class="fa fa-fw fa-close" aria-hidden="true"></i> ' . trans('laravelblocker::laravelblocker.modals.btnCancel'), array('class' => 'btn btn-outline pull-left btn-flat', 'type' => 'button', 'data-dismiss' => 'modal' )) !!}
-                {!! Form::button('<i class="fa ' . $actionBtnIcon . '" aria-hidden="true"></i> ' . $btnSubmitText, array('class' => 'btn btn-' . $modalClass . ' pull-right btn-flat', 'type' => 'button', 'id' => 'confirm' )) !!}
+                {{ html()->button('<i class="fa fa-fw fa-close" aria-hidden="true"></i> ' . trans('laravelblocker::laravelblocker.modals.btnCancel'))
+                    ->class('btn btn-outline pull-left btn-flat')
+                    ->type('button')
+                    ->attribute('data-dismiss', 'modal') }}
+                {{ html()->button('<i class="fa ' . $actionBtnIcon . '" aria-hidden="true"></i> ' . $btnSubmitText)
+                    ->class('btn btn-' . $modalClass . ' pull-right btn-flat')
+                    ->type('button')
+                    ->id('confirm') }}
             </div>
         </div>
     </div>

--- a/resources/views/vendor/scripts/search-blocked.blade.php
+++ b/resources/views/vendor/scripts/search-blocked.blade.php
@@ -58,8 +58,8 @@
                                 var showCellHtml = '<a class="btn btn-sm btn-success btn-block" href="blocker/' + val.id + '" data-toggle="tooltip" title="{{ trans("laravelblocker::laravelblocker.tooltips.show") }}">{!! trans("laravelblocker::laravelblocker.buttons.show") !!}</a>';
                                 var editCellHtml = '<a class="btn btn-sm btn-info btn-block" href="blocker/' + val.id + '/edit" data-toggle="tooltip" title="{{ trans("laravelblocker::laravelblocker.tooltips.edit") }}">{!! trans("laravelblocker::laravelblocker.buttons.edit") !!}</a>';
                                 var deleteCellHtml = '<form method="POST" action="/blocker/'+ val.id +'" accept-charset="UTF-8" data-toggle="tooltip" title="Delete Blocked Item">' +
-                                        '{!! Form::hidden("_method", "DELETE") !!}' +
-                                        '{!! csrf_field() !!}' +
+                                        '<input type="hidden" name="_method" value="DELETE">' +
+                                        '<input type="hidden" name="_token" value="{{ csrf_token() }}">' +
                                         '<button class="btn btn-danger btn-sm" type="button" style="width: 100%;" data-toggle="modal" data-target="#confirmDelete" data-title="Delete Blocked Item" data-message="{!! trans("laravelblocker::laravelblocker.modals.delete_blocked_message", ["blocked" => "'+val.name+'"]) !!}">' +
                                             '{!! trans("laravelblocker::laravelblocker.buttons.delete") !!}' +
                                         '</button>' +


### PR DESCRIPTION
## Summary
- replace Laravel Collective form usage across Blade templates with spatie/laravel-html helper calls and ensure CSRF/method spoofing
- swap macro registration to extend spatie/html, port custom HTML macros, and remove Collective aliases from configuration
- add spatie/laravel-html dependency and update supporting scripts and partials for token/method fields in JS-generated forms

## Testing
- ./vendor/bin/phpunit *(fails: database connection refused in test bootstrap)*

------
https://chatgpt.com/codex/tasks/task_e_68c920ce498c832a943c9f2ac688d277