### PR TITLE
Fix ESLint 9 setup and clean lint errors

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,22 +1,46 @@
-import * as tseslint from "@typescript-eslint/eslint-plugin";
-import parser from "@typescript-eslint/parser";
+import js from "@eslint/js";
+import tseslintPlugin from "@typescript-eslint/eslint-plugin";
+import tsParser from "@typescript-eslint/parser";
+import vuePlugin from "eslint-plugin-vue";
+import globals from "globals";
+
+const ignores = [
+  "node_modules/**",
+  "vendor/**",
+  "storage/**",
+  "public/**",
+  "bootstrap/cache/**",
+];
 
 export default [
   {
-    files: ["**/*.ts", "**/*.tsx", "**/*.vue"],
+    ignores,
+  },
+  {
     languageOptions: {
-      parser, // @typescript-eslint/parser
+      ecmaVersion: "latest",
+      sourceType: "module",
+      globals: {
+        ...globals.browser,
+      },
+    },
+  },
+  js.configs.recommended,
+  ...vuePlugin.configs["flat/recommended"],
+  {
+    files: ["**/*.ts", "**/*.tsx"],
+    languageOptions: {
+      parser: tsParser,
       parserOptions: {
         ecmaVersion: "latest",
         sourceType: "module",
-        project: ["./tsconfig.json"], // remove if not using type-aware linting
       },
     },
     plugins: {
-      "@typescript-eslint": tseslint,
+      "@typescript-eslint": tseslintPlugin,
     },
     rules: {
-      ...tseslint.configs.recommended.rules,
+      ...tseslintPlugin.configs.recommended.rules,
     },
   },
 ];

--- a/resources/assets/js/app.js
+++ b/resources/assets/js/app.js
@@ -7,7 +7,9 @@ import axios from "axios";
 import "@fortawesome/fontawesome-free/css/all.min.css";
 // import VueSecureHTML from 'vue-html-secure';
 
-Object.assign(window, { $: jQuery, jQuery });
+const $ = jQuery;
+
+Object.assign(window, { $, jQuery });
 window.jQuery = window.$ = $;
 window.Alpine = Alpine;
 // window.Vue = require('vue');
@@ -17,6 +19,7 @@ Alpine.start();
 axios.defaults.withCredentials = true;
 
 const app = createApp({});
+window.app = app;
 
 $.fn.extend({
   toggleText: function (a, b) {

--- a/resources/assets/js/bootstrap.js
+++ b/resources/assets/js/bootstrap.js
@@ -2,15 +2,18 @@ import axios from "axios";
 import Echo from "laravel-echo";
 import Pusher from "pusher-js";
 import * as Popper from "@popperjs/core";
+import jQuery from "jquery";
 import loadash from "lodash";
+
+const $ = jQuery;
 
 window._ = loadash;
 window.Popper = Popper;
 window.axios = axios;
 window.axios.defaults.headers.common["X-Requested-With"] = "XMLHttpRequest";
 window.axios.defaults.withCredentials = true;
-// window.Vue = require("vue");
 window.Pusher = Pusher;
+window.$ = window.jQuery = $;
 
 // const password = require("password-strength-meter");
 const token = document.head.querySelector('meta[name="csrf-token"]');
@@ -23,14 +26,6 @@ if (token) {
   );
 }
 
-try {
-  // var $ = require('jquery');
-  // window.$ = window.jQuery = require("jquery");
-  // require("hideshowpassword");
-  // require('password-strength-meter');
-} catch (e) {}
-
-/*eslint-disable */
 window.Echo = new Echo({
   broadcaster: "pusher",
   key: import.meta.env.VITE_PUSHER_APP_KEY,
@@ -43,7 +38,7 @@ window.Echo = new Echo({
   forceTLS: (import.meta.env.VITE_PUSHER_SCHEME ?? "https") === "https",
   enabledTransports: ["ws", "wss"],
 });
-/*eslint-enable */
+ 
 
 $.fn.extend({
   toggleText(a, b) {

--- a/resources/assets/js/components/ExampleComponent.vue
+++ b/resources/assets/js/components/ExampleComponent.vue
@@ -3,9 +3,13 @@
     <div class="row justify-content-center">
       <div class="col-md-8">
         <div class="card card-default">
-          <div class="card-header">Example Component</div>
+          <div class="card-header">
+            Example Component
+          </div>
 
-          <div class="card-body">I'm an example component.</div>
+          <div class="card-body">
+            I'm an example component.
+          </div>
         </div>
       </div>
     </div>

--- a/resources/assets/js/components/UsersCount.vue
+++ b/resources/assets/js/components/UsersCount.vue
@@ -3,9 +3,14 @@
     <div class="row">
       <div class="col-md-8 offset-md-2">
         <div class="card">
-          <div class="card-header">Current Users Online</div>
+          <div class="card-header">
+            Current Users Online
+          </div>
           <div class="card-body">
-            <canvas id="myChart" height="100"></canvas>
+            <canvas
+              id="myChart"
+              height="100"
+            />
           </div>
         </div>
       </div>
@@ -21,6 +26,7 @@ export default {
     return {
       count: 0,
       labels: ["Online"],
+      chart: null,
     };
   },
   mounted() {
@@ -30,7 +36,7 @@ export default {
   methods: {
     drawChart() {
       const ctx = document.getElementById("myChart");
-      const myChart = new Chart(ctx, {
+      this.chart = new Chart(ctx, {
         type: "bar",
         data: {
           labels: this.labels,
@@ -56,16 +62,20 @@ export default {
       });
     },
     update() {
-      Echo.join("chart")
+      if (!window.Echo) {
+        return;
+      }
+
+      window.Echo.join("chart")
         .here((users) => {
           this.count = users.length;
           this.drawChart();
         })
-        .joining((user) => {
+        .joining(() => {
           this.count++;
           this.drawChart();
         })
-        .leaving((user) => {
+        .leaving(() => {
           this.count--;
           this.drawChart();
         });


### PR DESCRIPTION
## Summary
- adopt an ESLint 9 flat configuration that enables browser globals, Vue support, and TypeScript linting
- expose the Vue app and jQuery on window so shared scripts have defined globals and remove dead try/catch
- update the UsersCount chart component to reuse the global Echo instance safely and satisfy lint rules

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c98d0e037c832aa2964a780e6fd2e0